### PR TITLE
Pin zsh-syntax-highlighting plugin commit in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -18,7 +18,6 @@ install_zsh_syntax_highlighting() {
   local plugin_dir="$1"
   local pinned_commit="1d85c692615a25fe2293bdd44b34c217d5d2bf04"
   local repo_url="https://github.com/zsh-users/zsh-syntax-highlighting.git"
-  local pinned_ref="master"
 
   if ! command -v git &> /dev/null; then
     echo "git is required to install zsh-syntax-highlighting" >&2
@@ -47,7 +46,7 @@ install_zsh_syntax_highlighting() {
 
   git init -q "$tmp_dir" &&
   git -C "$tmp_dir" remote add origin "$repo_url" &&
-  git -C "$tmp_dir" fetch --depth 1 origin "$pinned_ref" &&
+  git -C "$tmp_dir" fetch --depth 1 origin "$pinned_commit" &&
   git -C "$tmp_dir" checkout --detach -q FETCH_HEAD || return 1
 
   if [ "$(git -C "$tmp_dir" rev-parse HEAD)" != "$pinned_commit" ]; then

--- a/setup.sh
+++ b/setup.sh
@@ -14,6 +14,23 @@ install_starship() {
   fi
 }
 
+install_zsh_syntax_highlighting() {
+  local plugin_dir="$1"
+  local pinned_commit="f1944d8f8b7628f409f90adcf1d40eb6aa797e53"
+
+  if [ -d "$plugin_dir" ]; then
+    echo "zsh-syntax-highlighting plugin already installed"
+    return
+  fi
+
+  echo "Installing zsh-syntax-highlighting plugin at pinned commit..."
+  mkdir -p "$(dirname "$plugin_dir")"
+  git init -q "$plugin_dir"
+  git -C "$plugin_dir" remote add origin https://github.com/zsh-users/zsh-syntax-highlighting.git
+  git -C "$plugin_dir" fetch --depth 1 origin "$pinned_commit"
+  git -C "$plugin_dir" checkout --detach -q FETCH_HEAD
+}
+
 if [[ "$(uname)" == "Darwin" ]]; then
   # Install Homebrew if not present
   if ! command -v brew &> /dev/null; then
@@ -58,12 +75,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
 
   # Install Oh My Zsh plugins
   ZSH_HIGHLIGHT_DIR="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting"
-  if [ ! -d "$ZSH_HIGHLIGHT_DIR" ]; then
-    echo "Installing zsh-syntax-highlighting plugin..."
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_HIGHLIGHT_DIR"
-  else
-    echo "zsh-syntax-highlighting plugin already installed"
-  fi
+  install_zsh_syntax_highlighting "$ZSH_HIGHLIGHT_DIR"
   
   # Install iTerm2 shell integration
   if [ ! -f ~/.iterm2_shell_integration.zsh ]; then
@@ -81,8 +93,5 @@ elif [[ "$(uname)" == "Linux" ]]; then
 
   # Install Oh My Zsh plugins
   ZSH_HIGHLIGHT_DIR="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting"
-  if [ ! -d "$ZSH_HIGHLIGHT_DIR" ]; then
-    mkdir -p "$(dirname "$ZSH_HIGHLIGHT_DIR")"
-    git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "$ZSH_HIGHLIGHT_DIR"
-  fi
+  install_zsh_syntax_highlighting "$ZSH_HIGHLIGHT_DIR"
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -16,19 +16,48 @@ install_starship() {
 
 install_zsh_syntax_highlighting() {
   local plugin_dir="$1"
-  local pinned_commit="f1944d8f8b7628f409f90adcf1d40eb6aa797e53"
+  local pinned_commit="1d85c692615a25fe2293bdd44b34c217d5d2bf04"
+  local repo_url="https://github.com/zsh-users/zsh-syntax-highlighting.git"
+  local pinned_ref="master"
 
-  if [ -d "$plugin_dir" ]; then
-    echo "zsh-syntax-highlighting plugin already installed"
-    return
+  if ! command -v git &> /dev/null; then
+    echo "git is required to install zsh-syntax-highlighting" >&2
+    return 1
   fi
 
-  echo "Installing zsh-syntax-highlighting plugin at pinned commit..."
-  mkdir -p "$(dirname "$plugin_dir")"
-  git init -q "$plugin_dir"
-  git -C "$plugin_dir" remote add origin https://github.com/zsh-users/zsh-syntax-highlighting.git
-  git -C "$plugin_dir" fetch --depth 1 origin "$pinned_commit"
-  git -C "$plugin_dir" checkout --detach -q FETCH_HEAD
+  if [ -d "$plugin_dir/.git" ]; then
+    local current_commit
+    current_commit="$(git -C "$plugin_dir" rev-parse HEAD 2>/dev/null || true)"
+    if [ "$current_commit" = "$pinned_commit" ]; then
+      echo "zsh-syntax-highlighting already pinned at expected commit"
+      return 0
+    fi
+    echo "Re-pinning existing zsh-syntax-highlighting checkout..."
+  elif [ -e "$plugin_dir" ]; then
+    echo "Replacing existing zsh-syntax-highlighting directory with pinned checkout..."
+  else
+    echo "Installing zsh-syntax-highlighting plugin at pinned commit..."
+  fi
+
+  mkdir -p "$(dirname "$plugin_dir")" || return 1
+
+  local tmp_dir
+  tmp_dir="$(mktemp -d "$(dirname "$plugin_dir")/.zsh-syntax-highlighting.XXXXXX")" || return 1
+  trap 'rm -rf "$tmp_dir"' RETURN
+
+  git init -q "$tmp_dir" &&
+  git -C "$tmp_dir" remote add origin "$repo_url" &&
+  git -C "$tmp_dir" fetch --depth 1 origin "$pinned_ref" &&
+  git -C "$tmp_dir" checkout --detach -q FETCH_HEAD || return 1
+
+  if [ "$(git -C "$tmp_dir" rev-parse HEAD)" != "$pinned_commit" ]; then
+    echo "Expected zsh-syntax-highlighting commit $pinned_commit after fetch, got $(git -C "$tmp_dir" rev-parse HEAD)" >&2
+    return 1
+  fi
+
+  rm -rf "$plugin_dir"
+  mv "$tmp_dir" "$plugin_dir" || return 1
+  trap - RETURN
 }
 
 if [[ "$(uname)" == "Darwin" ]]; then
@@ -75,7 +104,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
 
   # Install Oh My Zsh plugins
   ZSH_HIGHLIGHT_DIR="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting"
-  install_zsh_syntax_highlighting "$ZSH_HIGHLIGHT_DIR"
+  install_zsh_syntax_highlighting "$ZSH_HIGHLIGHT_DIR" || exit 1
   
   # Install iTerm2 shell integration
   if [ ! -f ~/.iterm2_shell_integration.zsh ]; then
@@ -93,5 +122,5 @@ elif [[ "$(uname)" == "Linux" ]]; then
 
   # Install Oh My Zsh plugins
   ZSH_HIGHLIGHT_DIR="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting"
-  install_zsh_syntax_highlighting "$ZSH_HIGHLIGHT_DIR"
+  install_zsh_syntax_highlighting "$ZSH_HIGHLIGHT_DIR" || exit 1
 fi

--- a/setup.sh
+++ b/setup.sh
@@ -54,8 +54,23 @@ install_zsh_syntax_highlighting() {
     return 1
   fi
 
-  rm -rf "$plugin_dir"
-  mv "$tmp_dir" "$plugin_dir" || return 1
+  local backup_dir=""
+  if [ -e "$plugin_dir" ]; then
+    backup_dir="$(dirname "$plugin_dir")/.zsh-syntax-highlighting-backup.$(basename "$plugin_dir").$$"
+    rm -rf "$backup_dir"
+    mv "$plugin_dir" "$backup_dir" || return 1
+  fi
+
+  if ! mv "$tmp_dir" "$plugin_dir"; then
+    if [ -n "$backup_dir" ] && [ -e "$backup_dir" ]; then
+      command mv "$backup_dir" "$plugin_dir" || true
+    fi
+    return 1
+  fi
+
+  if [ -n "$backup_dir" ] && [ -e "$backup_dir" ]; then
+    rm -rf "$backup_dir"
+  fi
   trap - RETURN
 }
 


### PR DESCRIPTION
### Motivation
- The setup flow previously performed an unauthenticated, unpinned `git clone` of `zsh-syntax-highlighting`, which is sourced on shell startup and creates a supply-chain execution risk. 
- A compromised upstream repo or intercepted clone could execute arbitrary code during shell initialization. 
- The change aims to reduce that risk while preserving the existing setup behavior and idempotence.

### Description
- Add a new helper `install_zsh_syntax_highlighting` in `setup.sh` that installs the plugin from a specific pinned upstream commit instead of cloning the repository's default branch. 
- The helper now fetches the pinned commit directly into a temporary directory, verifies that the fetched `HEAD` matches the expected pinned commit, and then swaps the checkout into place atomically. 
- Replace the previous unconditional `git clone` usage in both the macOS and Linux branches with a call to `install_zsh_syntax_highlighting` to keep behavior consistent. 
- Preserve idempotence by leaving already-pinned installs alone, while re-pinning stale existing checkouts and replacing broken/non-git directories with a clean pinned checkout.

### Testing
- `bash -n setup.sh`
- Fresh-install smoke test: ran `install_zsh_syntax_highlighting` into an empty temp directory and verified `HEAD` resolves to the pinned commit
- Re-pin smoke test: checked out the pinned commit's parent in a temp clone, reran the helper, and verified it moved back to the pinned commit
- Broken-directory recovery test: created a non-git plugin directory, reran the helper, and verified it was replaced with a valid pinned checkout
- Failure-path test: mocked `git fetch` to fail and verified the helper returned non-zero without leaving `plugin_dir` behind
- Verified the pinned commit exists upstream, validated that GitHub serves it directly via `git fetch --depth 1 origin <sha>`, and kept the post-fetch `HEAD` verification

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af23eb54b88322988369d0cd078ca1)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the shell setup flow to perform a pinned, atomic git checkout; while it reduces supply-chain risk, it also adds more git/move logic that could fail or behave differently on user machines.
> 
> **Overview**
> Updates `setup.sh` to install `zsh-syntax-highlighting` from a **pinned commit** instead of an unpinned `git clone` of the default branch.
> 
> Adds an `install_zsh_syntax_highlighting` helper that fetches the exact SHA into a temp dir, verifies `HEAD`, and then swaps it into place (with backup/restore), and uses this helper for both macOS and Linux setup paths, failing the script if installation fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 01d493c75b450fd79d951e1b9de9f325c1e3dcb2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consolidated duplicate plugin installation logic for cleaner, more maintainable setup flow.
* **Bug Fixes / Reliability**
  * Made plugin installation idempotent and atomic to avoid partial updates and reduce failures.
  * Unified error handling so setup fails predictably on installation errors, improving overall install robustness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

