### PR TITLE
Harden setup bootstrap by verifying installer scripts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -40,7 +40,8 @@ run_verified_script() {
     return 1
   fi
 
-  /bin/sh "$tmp_script" "$@"
+  chmod +x "$tmp_script"
+  "$tmp_script" "$@"
 }
 
 # Define a function to install Oh My Zsh

--- a/setup.sh
+++ b/setup.sh
@@ -21,9 +21,10 @@ sha256_file() {
 }
 
 run_verified_script() {
-  local url="$1"
-  local expected_sha256="$2"
-  shift 2
+  local interpreter="$1"
+  local url="$2"
+  local expected_sha256="$3"
+  shift 3
 
   local tmp_script
   tmp_script="$(mktemp)"
@@ -40,21 +41,20 @@ run_verified_script() {
     return 1
   fi
 
-  chmod +x "$tmp_script"
-  "$tmp_script" "$@"
+  "$interpreter" "$tmp_script" "$@"
 }
 
 # Define a function to install Oh My Zsh
 install_oh_my_zsh() {
   if [ ! -d "$HOME/.oh-my-zsh" ]; then
-    run_verified_script "$OH_MY_ZSH_INSTALL_URL" "$OH_MY_ZSH_INSTALL_SHA256" --unattended
+    run_verified_script /bin/sh "$OH_MY_ZSH_INSTALL_URL" "$OH_MY_ZSH_INSTALL_SHA256" --unattended
   fi
 }
 
 # Define a function to install Starship
 install_starship() {
   if ! command -v starship &> /dev/null; then
-    run_verified_script "$STARSHIP_INSTALL_URL" "$STARSHIP_INSTALL_SHA256" -y
+    run_verified_script /bin/sh "$STARSHIP_INSTALL_URL" "$STARSHIP_INSTALL_SHA256" -y
   fi
 }
 
@@ -62,7 +62,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   # Install Homebrew if not present
   if ! command -v brew &> /dev/null; then
     echo "Installing Homebrew..."
-    run_verified_script "$HOMEBREW_INSTALL_URL" "$HOMEBREW_INSTALL_SHA256"
+    run_verified_script /bin/bash "$HOMEBREW_INSTALL_URL" "$HOMEBREW_INSTALL_SHA256"
   else
     echo "Homebrew already installed"
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -47,7 +47,7 @@ run_verified_script() {
 # Define a function to install Oh My Zsh
 install_oh_my_zsh() {
   if [ ! -d "$HOME/.oh-my-zsh" ]; then
-    run_verified_script /bin/sh "$OH_MY_ZSH_INSTALL_URL" "$OH_MY_ZSH_INSTALL_SHA256" --unattended
+    run_verified_script /bin/sh "$OH_MY_ZSH_INSTALL_URL" "$OH_MY_ZSH_INSTALL_SHA256"
   fi
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,16 +1,59 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
+OH_MY_ZSH_INSTALL_URL="https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/1e3abc123f690c9bdd416e8224f1beb47c96f1c7/tools/install.sh"
+OH_MY_ZSH_INSTALL_SHA256="ce0b7c94aa04d8c7a8137e45fe5c4744e3947871f785fd58117c480c1bf49352"
+
+STARSHIP_INSTALL_URL="https://raw.githubusercontent.com/starship/starship/v1.22.1/install/install.sh"
+STARSHIP_INSTALL_SHA256="56da063be2d93348b6181275b235108ad6dd39bc2c2faee053889f57666ac30a"
+
+HOMEBREW_INSTALL_URL="https://raw.githubusercontent.com/Homebrew/install/a5e5c3da45367f1b14512c457728fea75eb18d23/install.sh"
+HOMEBREW_INSTALL_SHA256="1c9db64f27d7487ecf74fe3543b96beb1f78039cc92745c3e825a9a7ccefec80"
+
+sha256_file() {
+  local file="$1"
+  if command -v sha256sum &> /dev/null; then
+    sha256sum "$file" | awk '{print $1}'
+  else
+    shasum -a 256 "$file" | awk '{print $1}'
+  fi
+}
+
+run_verified_script() {
+  local url="$1"
+  local expected_sha256="$2"
+  shift 2
+
+  local tmp_script
+  tmp_script="$(mktemp)"
+  trap 'rm -f "$tmp_script"' RETURN
+
+  curl -fsSL "$url" -o "$tmp_script"
+
+  local actual_sha256
+  actual_sha256="$(sha256_file "$tmp_script")"
+  if [ "$actual_sha256" != "$expected_sha256" ]; then
+    echo "Checksum verification failed for $url" >&2
+    echo "Expected: $expected_sha256" >&2
+    echo "Actual:   $actual_sha256" >&2
+    return 1
+  fi
+
+  /bin/sh "$tmp_script" "$@"
+}
+
 # Define a function to install Oh My Zsh
 install_oh_my_zsh() {
   if [ ! -d "$HOME/.oh-my-zsh" ]; then
-    sh -c "$(curl -fsSL https://raw.githubusercontent.com/robbyrussell/oh-my-zsh/master/tools/install.sh)" --unattended
+    run_verified_script "$OH_MY_ZSH_INSTALL_URL" "$OH_MY_ZSH_INSTALL_SHA256" --unattended
   fi
 }
 
 # Define a function to install Starship
 install_starship() {
   if ! command -v starship &> /dev/null; then
-    curl -fsSL https://starship.rs/install.sh | sh -s -- -y
+    run_verified_script "$STARSHIP_INSTALL_URL" "$STARSHIP_INSTALL_SHA256" -y
   fi
 }
 
@@ -18,7 +61,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
   # Install Homebrew if not present
   if ! command -v brew &> /dev/null; then
     echo "Installing Homebrew..."
-    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    run_verified_script "$HOMEBREW_INSTALL_URL" "$HOMEBREW_INSTALL_SHA256"
   else
     echo "Homebrew already installed"
   fi


### PR DESCRIPTION
### Motivation
- The original `setup.sh` executed upstream installer scripts directly via `curl | sh` and `bash -c "$(curl ...)"`, which allows remote code execution if upstream or the TLS path is compromised. 
- Provide a minimal, low-risk mitigation that preserves the existing bootstrap flow and runtime behavior while reducing supply-chain attack surface.

### Description
- Add strict shell mode with `set -euo pipefail` and pin installer URLs to immutable commits/tags for Oh My Zsh, Starship, and Homebrew via `OH_*_INSTALL_URL` variables. 
- Introduce `sha256_file` and `run_verified_script` helpers that download installer scripts to a temp file, verify the SHA-256 digest, and only execute the script when the checksum matches. 
- Replace direct remote execution calls with `run_verified_script` calls for Oh My Zsh, Starship, and Homebrew while keeping the existing Starship/Homebrew behavior and preserving the prior Oh My Zsh invocation semantics. 

### Testing
- `bash -n setup.sh`
- Reproduced the original Homebrew regression by running the pinned installer under `/bin/sh` and confirming it aborts in POSIX mode
- Smoke-tested `run_verified_script` locally with a Bash-only script via `/bin/bash` and a POSIX shell script via `/bin/sh`, both downloaded through the checksum-verification path
- Recomputed the pinned SHA-256 digests for the Oh My Zsh, Starship, and Homebrew installer URLs and confirmed they match the values in `setup.sh`
- Validated that the old Oh My Zsh `sh -c` form assigned `--unattended` to `$0` rather than `$@`, then updated the verified installer path to preserve that prior behavior

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af24adeddc83229613af04767fab4a)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches bootstrap/installer flow: checksum failures or pinned upstream changes could break initial setup on developer machines, but logic is small and mostly additive.
> 
> **Overview**
> Hardens `setup.sh` by enabling strict shell mode (`set -euo pipefail`) and replacing `curl | sh`-style installs with a verified-download flow.
> 
> Installer scripts for Oh My Zsh, Starship, and Homebrew are now pinned to immutable URLs and executed only after SHA-256 verification via new `sha256_file`/`run_verified_script` helpers (with Homebrew explicitly run under `/bin/bash`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d94c22c90f8cc508f5a93172f8c5997c09c6d735. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Installers (Oh My Zsh, Starship, Homebrew) are now downloaded and verified with SHA‑256 before execution.
  * Installer process fails fast on verification or execution errors to avoid partial/unsafe installs.
  * Installer metadata centralized to improve repeatability and auditability of installations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

