### PR TITLE
[codex] Add dotfiles CI and dev workflow

### DIFF
--- a/.config/yadm/bootstrap
+++ b/.config/yadm/bootstrap
@@ -3,9 +3,6 @@ set -euo pipefail
 
 echo "=== Starting yadm bootstrap ==="
 
-# Detect OS
-os=$(uname -s)
-
 # Run yadm alternates (only needed for yadm)
 echo "Setting up yadm alternates..."
 yadm alt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
       - master
       - main
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: Validate dotfiles
@@ -35,4 +38,4 @@ jobs:
 
           test -f "$temp_home/.Brewfile"
           test -e "$temp_home/.gitconfig.local"
-          grep -q "name = Pablo Valero" "$temp_home/.gitconfig.local"
+          grep -qE '^[[:space:]]*name[[:space:]]*=' "$temp_home/.gitconfig.local"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+      - main
 
 jobs:
   validate:
@@ -33,5 +34,5 @@ jobs:
           HOME="$temp_home" yadm alt --force
 
           test -f "$temp_home/.Brewfile"
-          test -L "$temp_home/.gitconfig.local"
-          test "$(readlink "$temp_home/.gitconfig.local")" = ".gitconfig.local##class.personal"
+          test -e "$temp_home/.gitconfig.local"
+          grep -q "name = Pablo Valero" "$temp_home/.gitconfig.local"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+
+jobs:
+  validate:
+    name: Validate dotfiles
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Install validation tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck zsh yadm
+
+      - name: Run local checks
+        run: ./scripts/check.sh
+
+      - name: Render yadm alternates in a temporary home
+        run: |
+          temp_home="$(mktemp -d)"
+          trap 'rm -rf "$temp_home"' EXIT
+
+          HOME="$temp_home" yadm clone --no-bootstrap "$GITHUB_WORKSPACE"
+          HOME="$temp_home" yadm config local.class personal
+          HOME="$temp_home" yadm alt --force
+
+          test -f "$temp_home/.Brewfile"
+          test -L "$temp_home/.gitconfig.local"
+          test "$(readlink "$temp_home/.gitconfig.local")" = ".gitconfig.local##class.personal"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-.config/iterm2/AppSupport
 /Library/Application Support/Code/User/*
 .gitconfig.auth

--- a/.zshrc
+++ b/.zshrc
@@ -141,10 +141,6 @@ if [ "$OS" = "macos" ]; then
    if command -v bit >/dev/null 2>&1; then
       complete -o nospace -C "$(command -v bit)" bit
    fi
-   # iTerm2 integration
-   if [[ -f "$HOME/.iterm2_shell_integration.zsh" ]]; then
-      source "$HOME/.iterm2_shell_integration.zsh"
-   fi
    # NVM - commented out in favor of nodenv
    # export NVM_DIR="$HOME/.nvm"
    # [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"                   # This loads nvm

--- a/.zshrc_custom/functions.zsh
+++ b/.zshrc_custom/functions.zsh
@@ -96,15 +96,6 @@ function quick-look() {
 preman() {
         mandoc -T pdf "$(/usr/bin/man -w $@)" | open -fa Preview
 }
-# Expose kubernetes context for iTerm
-iterm2_print_user_vars() {
-        KUBECONTEXT=$(
-                CTX=$(kubectl config current-context) 2>/dev/null
-                if [ $? -eq 0 ]; then echo $CTX; fi
-        )
-        iterm2_set_user_var kubeContext $KUBECONTEXT
-}
-
 # Function to handle Git command suggestions
 copilot_git_suggest() {
         gh copilot suggest -t git "$@"

--- a/README.md
+++ b/README.md
@@ -23,6 +23,35 @@ yadm pull
 yadm bootstrap  # Re-run to apply any new setup changes
 ```
 
+## Development Workflow
+
+Use a normal clone for non-trivial edits, then apply reviewed changes back to
+the live yadm checkout after merge. This keeps `$HOME` closer to a deployed
+worktree instead of the place where every experiment happens.
+
+```bash
+mkdir -p ~/Developer
+git clone https://github.com/pevd950/dotfiles.git ~/Developer/dotfiles
+cd ~/Developer/dotfiles
+git switch -c topic/my-change
+
+# edit, validate, commit, push, and open a PR
+./scripts/check.sh
+gh pr create --fill
+```
+
+After the PR merges:
+
+```bash
+cd ~
+yadm pull --ff-only
+yadm alt
+yadm bootstrap
+```
+
+For tiny emergency fixes, yadm can still be used directly in `$HOME`, but prefer
+branches and PRs for bootstrap, shell startup, agent-skill, and package changes.
+
 ## 📁 Structure
 
 ```
@@ -67,7 +96,6 @@ Shared environment bootstrap used by yadm bootstrap and Codespaces:
 - Starship prompt
 - Homebrew installation (if needed) and `brew bundle --global`
 - Development tools via Brewfile plus Node version setup with nodenv
-- iTerm2 shell integration
 
 ### `.config/yadm/bootstrap`
 Full yadm bootstrap:
@@ -87,11 +115,14 @@ Both scripts are designed to be safe to re-run.
 ## 🧪 Testing
 
 ```bash
-# Test bootstrap after changes
-yadm bootstrap
+# Fast local validation for shell/bootstrap changes
+./scripts/check.sh
 
 # Force regenerate alternates
 yadm alt --force
+
+# Apply bootstrap changes to the current machine only after review/merge
+yadm bootstrap
 ```
 
 ## 🆘 Common Issues

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ yadm bootstrap
 ```
 
 For tiny emergency fixes, yadm can still be used directly in `$HOME`, but prefer
-branches and PRs for bootstrap, shell startup, agent-skill, and package changes.
+branches and PRs for bootstrap, shell startup, agent-skills, and package changes.
 
 ## 📁 Structure
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+bash_files=(
+  setup.sh
+  .config/yadm/bootstrap
+  .zshrc_custom/bin/coderabbit
+  .zshrc_custom/bin/cr
+)
+
+zsh_files=(
+  .zshenv
+  .zshrc
+  .zshrc_custom/alias.zsh
+  .zshrc_custom/functions.zsh
+  .zshrc_custom/macos-exports
+  .zshrc_custom/debian-exports
+)
+
+shellcheck "${bash_files[@]}"
+bash -n "${bash_files[@]}"
+zsh -n "${zsh_files[@]}"

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -20,5 +20,11 @@ zsh_files=(
 )
 
 shellcheck "${bash_files[@]}"
-bash -n "${bash_files[@]}"
-zsh -n "${zsh_files[@]}"
+
+for file in "${bash_files[@]}"; do
+  bash -n "$file"
+done
+
+for file in "${zsh_files[@]}"; do
+  zsh -n "$file"
+done

--- a/setup.sh
+++ b/setup.sh
@@ -206,14 +206,6 @@ if [[ "$(uname)" == "Darwin" ]]; then
   ZSH_HIGHLIGHT_DIR="${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/plugins/zsh-syntax-highlighting"
   install_zsh_syntax_highlighting "$ZSH_HIGHLIGHT_DIR" || exit 1
   
-  # Install iTerm2 shell integration
-  if [ ! -f ~/.iterm2_shell_integration.zsh ]; then
-    echo "Installing iTerm2 shell integration..."
-    curl -L https://iterm2.com/shell_integration/zsh \
-      -o ~/.iterm2_shell_integration.zsh
-  else
-    echo "iTerm2 shell integration already installed"
-  fi
 elif [[ "$(uname)" == "Linux" ]]; then
   # TODO: This should be shared
   # Install tools


### PR DESCRIPTION
## Summary
- Add a lightweight CI workflow for dotfiles validation on PRs and pushes to `master`
- Add `scripts/check.sh` so local validation and CI run the same shell checks
- Document a safer dev workflow using `~/Developer/dotfiles` branches and PRs before applying changes to the live yadm checkout
- Remove unused iTerm2 bootstrap and shell integration hooks

## Validation
- `./scripts/check.sh`
- Temp-home yadm render smoke test:
  - `HOME="$tmp_home" yadm clone --no-bootstrap /Users/pablovalero/Developer/dotfiles`
  - `HOME="$tmp_home" yadm config local.class personal`
  - `HOME="$tmp_home" yadm alt --force`
  - verified `.Brewfile` exists and `.gitconfig.local` renders expected personal git config content
- `act -n -P ubuntu-latest=ghcr.io/catthehacker/ubuntu:act-latest`

## Follow-up notes
This PR intentionally does not run `yadm bootstrap` in CI because bootstrap still performs real installation and machine mutation. The next dotfiles cleanup/refactor should consider:

- splitting bootstrap into checkable phases
- adding a `--dry-run` mode for install/link/package operations
- adding Linux-focused validation instead of treating Linux as a second-class branch
- adding a container-based smoke test that clones the dotfiles into a fresh HOME and validates bootstrap behavior without touching a real workstation
- pruning tools and packages that are no longer used

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds non-mutating CI validation and documentation, plus removes iTerm2 integration hooks; no production services or sensitive auth/data logic involved.
> 
> **Overview**
> Adds a lightweight GitHub Actions CI job that runs `./scripts/check.sh` (ShellCheck + `bash -n`/`zsh -n`) on PRs and pushes to `main`/`master`, plus a temp-`HOME` smoke test that `yadm`-clones the repo and verifies alternates render expected outputs.
> 
> Introduces `scripts/check.sh` to unify local and CI validation, updates README with a PR-based development workflow and testing guidance, and removes unused iTerm2 bootstrap/shell hooks (including dropping an unused OS detect in `yadm/bootstrap`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a01557d0b8b4d8ff6fc813df755b9fa9737c982e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CI workflow for automatic validation of changes
  * Added strict local shell validation script for development

* **Documentation**
  * Added development workflow and fast local validation instructions to README

* **Chores**
  * Removed iTerm2 shell integration from setup and shell configs
  * Removed iTerm2-specific Kubernetes context export
  * Simplified bootstrap flow and related initial checks
  * Removed one iTerm2-related ignore pattern from VCS ignore list

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/9?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
