### PR TITLE
[codex] Remove hardcoded Projects guidance path

### DIFF
--- a/Projects/AGENTS.md
+++ b/Projects/AGENTS.md
@@ -2,7 +2,7 @@
 
 Keep global Codex instructions repo-agnostic and free of project-specific workflow.
 
-Use this file for cross-repo personal operations guidance that should apply to assistant work launched from `/Users/pablovalero/Projects`.
+Use this file for cross-repo personal operations guidance that should apply to assistant work launched from the project directories alongside this file.
 
 When a repository under this folder provides its own `AGENTS.md` or nested `AGENTS.md` files, treat those as the source of truth for repo-specific workflow, tooling, validation, GitHub process, and coding conventions.
 


### PR DESCRIPTION
## Summary
- remove the host-specific absolute path from `Projects/AGENTS.md`
- keep the guidance relative to the project directories alongside the file

## Validation
- `./scripts/check.sh`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that only affects wording of agent guidance and has no runtime impact.
> 
> **Overview**
> Removes the host-specific absolute path reference in `Projects/AGENTS.md` and rephrases the guidance to apply to work launched from the project directories alongside the file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d3d7fa3dea7dbb115f71a23fe9bb1120e8fc0528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance documentation to use more general path references instead of specific local directories, making instructions more universally applicable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/13?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->