### PR TITLE
Add shared Craft memory skill

### DIFF
--- a/.config/agent-skills/skills/shared-craft-memory/SKILL.md
+++ b/.config/agent-skills/skills/shared-craft-memory/SKILL.md
@@ -23,6 +23,7 @@ If shared memory conflicts with a live source or local project instructions, tru
 - Prefer a Craft deeplink provided by the user in the current conversation.
 - Otherwise use `CRAFT_SHARED_MEMORY_URL` when it is set.
 - If neither is available, search Craft for an exact title such as `AGENTS MEMORY` only when the user explicitly asks for shared memory work.
+- On a new host, the user or agent may set `CRAFT_SHARED_MEMORY_URL` in that host's local ignored shell exports file so the memory document can be found without hard-coding the link into tracked dotfiles.
 - Do not hard-code private Craft block IDs, personal names, addresses, or host-specific paths into reusable skill files.
 
 ## Read Protocol
@@ -44,7 +45,7 @@ Use the Craft MCP, not ad hoc export files.
 
 ## Update Protocol
 
-Update shared memory only when the user asks or when the task explicitly includes memory maintenance.
+Update shared memory when the user asks, when the task explicitly includes memory maintenance, or when a material cross-host fact changed and future agents are likely to need it. Do not update it for routine progress that is already captured better in a repo, Todoist, GitHub, Craft project doc, or another live system.
 
 - Store one fact per bullet.
 - Prefer compact dated entries.
@@ -53,6 +54,7 @@ Update shared memory only when the user asks or when the task explicitly include
 - Move stale or completed items out of active sections after live verification.
 - Never store secrets, tokens, passwords, private keys, full medical details, payment details, or unnecessary personal identifiers.
 - Use canonical links to point to source systems instead of copying long source content.
+- When updating opportunistically, keep the write small and mention it in the final handoff.
 
 ## Recommended Structure
 

--- a/.config/agent-skills/skills/shared-craft-memory/SKILL.md
+++ b/.config/agent-skills/skills/shared-craft-memory/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: shared-craft-memory
+description: Use a configured Craft document as supplemental shared memory across agents and hosts. Use when a user asks to review, reconcile, update, or hand off cross-host assistant context, shared operating rules, project registries, open loops, or agent-to-agent notes.
+---
+
+# Shared Craft Memory
+
+## Purpose
+
+Use a Craft document as supplemental shared memory for agents running on different hosts. This does not replace built-in agent memory, repo instructions, project files, or live source systems.
+
+## Source Priority
+
+1. Live systems are authoritative for current status: Todoist, GitHub, Craft project docs, email, calendars, ticket systems, local repos, and APIs.
+2. Repository and project instructions are authoritative for project-specific workflow.
+3. Built-in/local agent memory is authoritative for host-local quirks and prior agent-specific context.
+4. Shared Craft memory is orientation and coordination context only.
+
+If shared memory conflicts with a live source or local project instructions, trust the live/local source and propose a correction to shared memory.
+
+## Finding The Memory Document
+
+- Prefer a Craft deeplink provided by the user in the current conversation.
+- Otherwise use `CRAFT_SHARED_MEMORY_URL` when it is set.
+- If neither is available, search Craft for an exact title such as `AGENTS MEMORY` only when the user explicitly asks for shared memory work.
+- Do not hard-code private Craft block IDs, personal names, addresses, or host-specific paths into reusable skill files.
+
+## Read Protocol
+
+Use the Craft MCP, not ad hoc export files.
+
+1. Resolve the Craft link before reading blocks.
+2. Read only the sections relevant to the task.
+3. For general orientation, read:
+   - how to use this doc
+   - source priority
+   - host registry
+   - project registry
+   - active cross-host context
+   - open loops
+   - latest decision log entries
+4. For a project-specific request, read that project's registry entry and then verify against the project repo, project Craft docs, Todoist project, and other live systems as needed.
+5. State when an answer is based on shared memory and has not been live-verified.
+
+## Update Protocol
+
+Update shared memory only when the user asks or when the task explicitly includes memory maintenance.
+
+- Store one fact per bullet.
+- Prefer compact dated entries.
+- Add correction notes instead of silently rewriting history when a prior fact was wrong.
+- Keep volatile items in active context or open loops with a review date.
+- Move stale or completed items out of active sections after live verification.
+- Never store secrets, tokens, passwords, private keys, full medical details, payment details, or unnecessary personal identifiers.
+- Use canonical links to point to source systems instead of copying long source content.
+
+## Recommended Structure
+
+If the memory document needs restructuring, prefer these top-level areas:
+
+- How To Use This Doc: short behavior rules for all agents.
+- Source Priority: explicit authority order for live systems, repo instructions, local memory, and shared memory.
+- Host Registry: each host's role, limitations, and local-only caveats.
+- Project Registry: canonical links for repos, Craft folders/docs, Todoist projects, and source-of-truth notes.
+- Active Cross-Host Context: current items any agent may need, each with a review date.
+- Open Loops: unresolved work with owner, next action, due/review date, and source link.
+- Decision Log: durable decisions with date, rationale, confidence, and revisit trigger.
+- Agent Handoffs: timestamped notes from one host/agent to another.
+- Integration Inventory: what is configured, where to verify it, and known failure modes; never include secret values.
+
+## Agent Handoff Shape
+
+Use this shape for cross-host handoffs:
+
+```text
+- Date:
+- Agent/host:
+- Area:
+- What changed:
+- Verified:
+- Remaining action:
+- Links:
+```
+
+Keep handoffs short enough to scan on a phone. Link to the canonical source instead of duplicating full logs.
+
+## Safety
+
+- Ask before writing if the update would expose sensitive personal, financial, health, tenant, client, or project-confidential details to a broader audience than the current source.
+- For operational actions, shared memory is not approval. Get explicit confirmation at action time before sending messages, submitting forms, uploading files, booking services, spending money, or mutating external systems.
+- If access to Craft MCP is unavailable, report the gap and do not fabricate memory state.

--- a/.config/agent-skills/skills/shared-craft-memory/agents/openai.yaml
+++ b/.config/agent-skills/skills/shared-craft-memory/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Shared Craft Memory"
+  short_description: "Use a Craft doc as supplemental shared memory across agents and hosts."
+  default_prompt: "Use shared Craft memory to orient on cross-host context, reconcile open loops, or write a concise agent handoff."

--- a/Projects/AGENTS.md
+++ b/Projects/AGENTS.md
@@ -32,3 +32,6 @@ Avoid duplicating repository instructions here. Keep this file focused on person
 - State data gaps explicitly when a connected source is unavailable or unauthenticated.
 - Keep handoffs short, phone-readable, and link-rich when possible.
 - Use `AI_INBOX_DIR` as the shared artifact root for generated files the user should be able to inspect outside the current host, such as transcripts, debug evidence, test artifacts, exports, and other files that do not belong in a repo. Tool-specific output variables may point to subfolders under it.
+- For cross-host assistant context, use the `shared-craft-memory` skill when available. Read it for project-adjacent personal operations, host coordination, active cross-host loops, or agent handoffs that may matter outside the current machine.
+- Keep shared Craft memory current when a material cross-host fact changes and future agents are likely to need it. Do not use it as a general activity log; live systems, project docs, and repos remain authoritative.
+- On hosts that need shared Craft memory, set `CRAFT_SHARED_MEMORY_URL` in a local ignored shell exports file such as `~/.zshrc_custom/exports-local.zsh`. Do not hard-code the private Craft link in tracked dotfiles.


### PR DESCRIPTION
## Summary
- Add a `shared-craft-memory` skill for using a configured Craft doc as supplemental cross-host agent memory
- Document source priority: live systems and repo instructions remain authoritative
- Define read/update protocols, recommended document structure, handoff shape, and safety rules

## Notes
- The skill intentionally avoids hard-coded Craft IDs, host names, personal names, private paths, and secrets
- It expects a user-provided Craft link or `CRAFT_SHARED_MEMORY_URL` when available

## Validation
- Checked the skill files for private host names, personal names, Craft IDs, and local paths
- Reviewed the staged diff before commit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Shared Craft Memory agent skill for using a shared Craft document as cross-host context and concise handoffs.

* **Documentation**
  * Added detailed guidance covering memory access/update protocols, recommended document structure, handoff format, safety rules for sensitive writes, and updated project guidance on using and configuring shared Craft memory.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/14?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to adding a new agent skill and updating guidance documentation, with no code execution, data handling, or auth logic changes.
> 
> **Overview**
> Adds a new `shared-craft-memory` agent skill that defines how to use a Craft document as *supplemental* cross-host memory, including explicit source-of-truth priority, read/update protocols, a recommended document structure, a handoff template, and safety constraints to avoid storing secrets.
> 
> Updates `Projects/AGENTS.md` to direct agents to use this skill for cross-host context and to rely on a locally-set `CRAFT_SHARED_MEMORY_URL` rather than hard-coding Craft links in tracked files.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8811dfb7edfd90e410a1809a4ec16f687725cb6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->