### PR TITLE
Harden Debian dotfiles bootstrap

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -14,6 +14,7 @@ typeset -U path PATH
 # Paths and environment variables
 # Oh-my-zsh path
 export ZSH="$HOME/.oh-my-zsh"
+ZSH_CUSTOM="$HOME/.zshrc_custom"
 
 if [[ -d "$HOME/.local/bin" ]]; then
    path=("$HOME/.local/bin" $path)
@@ -22,11 +23,13 @@ fi
 if [[ "$(uname)" == "Darwin" ]]; then
    # macOS-specific configurations
    OS="macos"
-   source ~/.zshrc_custom/macos-exports
+   [[ -r "$ZSH_CUSTOM/macos-exports" ]] && source "$ZSH_CUSTOM/macos-exports"
 elif [[ "$(uname)" == "Linux" ]] && [ -e "/etc/debian_version" ]; then
    # Debian-based Linux configurations
    OS="debian"
-   source ~/.zshrc_custom/debian-exports
+   [[ -r "$ZSH_CUSTOM/debian-exports" ]] && source "$ZSH_CUSTOM/debian-exports"
+else
+   OS="unknown"
 fi
 
 # go module auth / proxy setup
@@ -49,23 +52,31 @@ ZSH_THEME=""
 plugins=(
    aliases
    colored-man-pages
-   copyfile
-   copypath
    docker
-   docker-compose
    encode64
    gh
    git
    golang
    per-directory-history
    history
-   kubectl
-   macos
    terraform
    web-search
    zsh-syntax-highlighting
-   1password
 )
+
+if command -v docker-compose >/dev/null 2>&1 || docker compose version >/dev/null 2>&1; then
+   plugins+=(docker-compose)
+fi
+
+if [[ "$OS" == "macos" ]]; then
+   plugins+=(
+      copyfile
+      copypath
+      kubectl
+      macos
+      1password
+   )
+fi
 #Disabled plugins
 # git-prompt
 # git-open
@@ -89,8 +100,11 @@ if [[ -n $SSH_CONNECTION ]]; then
 fi
 
 # Custom configurations
-ZSH_CUSTOM=~/.zshrc_custom
-source $ZSH/oh-my-zsh.sh
+if [[ -r "$ZSH/oh-my-zsh.sh" ]]; then
+   source "$ZSH/oh-my-zsh.sh"
+else
+   echo "Oh My Zsh not found at $ZSH; skipping plugin loading."
+fi
 
 # Source alias-local.zsh if it exists
 if [ -f "${ZSH_CUSTOM}/alias-local.zsh" ]; then
@@ -108,7 +122,7 @@ if [[ -d "${ZSH_CUSTOM}/bin" ]]; then
 fi
 
 # Init starship prompt when the terminal supports it.
-if [[ "${TERM:-}" != "dumb" ]]; then
+if [[ "${TERM:-}" != "dumb" ]] && command -v starship >/dev/null 2>&1; then
    eval "$(starship init zsh)"
 fi
 # Init shadowenv

--- a/.zshrc
+++ b/.zshrc
@@ -64,7 +64,9 @@ plugins=(
    zsh-syntax-highlighting
 )
 
-if command -v docker-compose >/dev/null 2>&1 || docker compose version >/dev/null 2>&1; then
+if command -v docker-compose >/dev/null 2>&1; then
+   plugins+=(docker-compose)
+elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
    plugins+=(docker-compose)
 fi
 

--- a/.zshrc_custom/alias.zsh
+++ b/.zshrc_custom/alias.zsh
@@ -1,5 +1,6 @@
-#macOS
-alias o="open ."
+if [[ "$(uname)" == "Darwin" ]]; then
+  alias o="open ."
+fi
 
 # Search through your command history and print the top 10 commands
 alias history-stat="history 0 | awk '{print \$2}' | sort | uniq -c | sort -n -r | head"
@@ -18,7 +19,9 @@ alias gpush="git push"
 alias gm="git merge"
 alias gcb="git checkout -b"
 alias gclone="git clone"
-alias gt="gittower ."
+if command -v gittower >/dev/null 2>&1; then
+  alias gt="gittower ."
+fi
 alias gcr="git rebase --continue"
 
 # Docker
@@ -41,37 +44,55 @@ alias ypush="yadm push"
 alias yadd="yadm add"
 
 # Editor
-alias zshrc="code ~/.zshrc"
+if command -v code >/dev/null 2>&1; then
+  alias zshrc="code ~/.zshrc"
+  alias mystarship='code ~/.config/starship.toml'
+  alias myaliases='code "$ZSH_CUSTOM"/alias.zsh'
+  alias myfunctions='code "$ZSH_CUSTOM"/functions.zsh'
+  alias myplugins='code "$ZSH_CUSTOM"/plugins.zsh'
+  alias myzshrc='code "$ZSH_CUSTOM"'
+  alias vsc='code .'
+  alias coden='code --new-window'
+fi
 alias nvzshrc='nvim ~/.zshrc'
 alias nvaliases='nvim "$ZSH_CUSTOM"/alias.zsh'
 alias nvstarship='nvim ~/.config/starship.toml'
-alias mystarship='code ~/.config/starship.toml'
-alias myaliases='code "$ZSH_CUSTOM"/alias.zsh'
-alias myfunctions='code "$ZSH_CUSTOM"/functions.zsh'
-alias myplugins='code "$ZSH_CUSTOM"/plugins.zsh'
-alias myzshrc='code "$ZSH_CUSTOM"'
 
 # Command Overrides
-alias bcat='bat --paging=never'
-alias dir='exa --icons -s=Name'
+if command -v bat >/dev/null 2>&1; then
+  alias bcat='bat --paging=never'
+elif command -v batcat >/dev/null 2>&1; then
+  alias bcat='batcat --paging=never'
+fi
+if command -v eza >/dev/null 2>&1; then
+  alias dir='eza --icons -s=Name'
+elif command -v exa >/dev/null 2>&1; then
+  alias dir='exa --icons -s=Name'
+fi
 alias nv='nvim'
-alias ql='quick-look'
-alias pman='preman'
+if [[ "$(uname)" == "Darwin" ]]; then
+  alias ql='quick-look'
+  alias pman='preman'
+fi
 
 # Apps
 
 # MacUpdater
-alias macupdater='/Applications/MacUpdater.app/Contents/Resources/macupdater_client'
-
-# VSCode
-alias vsc='code .'
-alias coden='code --new-window'
+if [[ "$(uname)" == "Darwin" && -x "/Applications/MacUpdater.app/Contents/Resources/macupdater_client" ]]; then
+  alias macupdater='/Applications/MacUpdater.app/Contents/Resources/macupdater_client'
+fi
 
 # Copilot CLI
-alias wts='copilot_what-the-shell'
-alias '??'='copilot_shell_suggest'
-alias "git?"='copilot_git_suggest'
-alias 'gh?'='copilot_gh_suggest'
+if gh extension list 2>/dev/null | grep -q '^copilot[[:space:]]'; then
+  alias wts='copilot_what-the-shell'
+  alias '??'='copilot_shell_suggest'
+  alias "git?"='copilot_git_suggest'
+  alias 'gh?'='copilot_gh_suggest'
+fi
 
 # Fun
-alias shrug="echo '¯\_(ツ)_/¯' | pbcopy"
+if command -v pbcopy >/dev/null 2>&1; then
+  alias shrug="echo '¯\_(ツ)_/¯' | pbcopy"
+else
+  alias shrug="echo '¯\_(ツ)_/¯'"
+fi

--- a/.zshrc_custom/alias.zsh
+++ b/.zshrc_custom/alias.zsh
@@ -83,7 +83,8 @@ if [[ "$(uname)" == "Darwin" && -x "/Applications/MacUpdater.app/Contents/Resour
 fi
 
 # Copilot CLI
-if gh extension list 2>/dev/null | grep -q '^copilot[[:space:]]'; then
+if command -v gh >/dev/null 2>&1 \
+  && gh extension list 2>/dev/null | grep -Eq '^gh[[:space:]]+copilot([[:space:]]|$)'; then
   alias wts='copilot_what-the-shell'
   alias '??'='copilot_shell_suggest'
   alias "git?"='copilot_git_suggest'

--- a/.zshrc_custom/debian-exports
+++ b/.zshrc_custom/debian-exports
@@ -18,7 +18,9 @@ fi
 
 # Many Debian Docker hosts install the Compose v2 plugin rather than the
 # legacy docker-compose binary.
-if ! command -v docker-compose >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
+if ! command -v docker-compose >/dev/null 2>&1 \
+  && command -v docker >/dev/null 2>&1 \
+  && docker compose version >/dev/null 2>&1; then
   docker-compose() {
     docker compose "$@"
   }

--- a/.zshrc_custom/debian-exports
+++ b/.zshrc_custom/debian-exports
@@ -1,8 +1,6 @@
 typeset -U path PATH
 
-# Debian hosts commonly use ~/.local/bin for user-scoped CLIs installed
-# outside apt. Keep it available without assuming Homebrew-on-Linux.
-[[ -d "$HOME/.local/bin" ]] && path=("$HOME/.local/bin" $path)
+# Keep traditional user-local bin scripts available without assuming Homebrew-on-Linux.
 [[ -d "$HOME/bin" ]] && path=("$HOME/bin" $path)
 
 # Debian package names do not always match the upstream command names.

--- a/.zshrc_custom/debian-exports
+++ b/.zshrc_custom/debian-exports
@@ -1,0 +1,27 @@
+typeset -U path PATH
+
+# Debian hosts commonly use ~/.local/bin for user-scoped CLIs installed
+# outside apt. Keep it available without assuming Homebrew-on-Linux.
+[[ -d "$HOME/.local/bin" ]] && path=("$HOME/.local/bin" $path)
+[[ -d "$HOME/bin" ]] && path=("$HOME/bin" $path)
+
+# Debian package names do not always match the upstream command names.
+# Prefer upstream command names when present; otherwise provide compatible
+# aliases for interactive use.
+if ! command -v fd >/dev/null 2>&1 && command -v fdfind >/dev/null 2>&1; then
+  alias fd='fdfind'
+fi
+
+if ! command -v bat >/dev/null 2>&1 && command -v batcat >/dev/null 2>&1; then
+  alias bat='batcat'
+fi
+
+# Many Debian Docker hosts install the Compose v2 plugin rather than the
+# legacy docker-compose binary.
+if ! command -v docker-compose >/dev/null 2>&1 && command -v docker >/dev/null 2>&1; then
+  docker-compose() {
+    docker compose "$@"
+  }
+fi
+
+export PATH

--- a/.zshrc_custom/functions.zsh
+++ b/.zshrc_custom/functions.zsh
@@ -1,5 +1,6 @@
 # Xcode
-openx() {
+if [[ "$(uname)" == "Darwin" ]]; then
+  openx() {
 	        local selected
 	        local -a workspaces projects
 
@@ -31,7 +32,8 @@ openx() {
 	        else
 	                echo "No Xcode project or workspace found"
 	        fi
-}
+  }
+fi
 
 # yadm function to auto-add Claude files
 yadm-claude() {
@@ -69,8 +71,10 @@ yadm-claude() {
 }
 
 # turn hidden files on/off in Finder
-function hiddenOn() { defaults write com.apple.Finder AppleShowAllFiles YES; }
-function hiddenOff() { defaults write com.apple.Finder AppleShowAllFiles NO; }
+if [[ "$(uname)" == "Darwin" ]]; then
+        function hiddenOn() { defaults write com.apple.Finder AppleShowAllFiles YES; }
+        function hiddenOff() { defaults write com.apple.Finder AppleShowAllFiles NO; }
+fi
 
 # myIP address
 function myip() {
@@ -78,24 +82,35 @@ function myip() {
 	        local addr
 	        local found=0
 
-	        for iface in ${(z)$(ifconfig -l)}; do
-	                addr=$(ipconfig getifaddr "$iface" 2>/dev/null) || continue
-	                printf "%-10s %s\n" "$iface" "$addr"
-	                found=1
-	        done
+	        if [[ "$(uname)" == "Darwin" ]]; then
+	                for iface in ${(z)$(ifconfig -l)}; do
+	                        addr=$(ipconfig getifaddr "$iface" 2>/dev/null) || continue
+	                        printf "%-10s %s\n" "$iface" "$addr"
+	                        found=1
+	                done
+	        elif command -v ip >/dev/null 2>&1; then
+	                while read -r _ iface _ addr _; do
+	                        printf "%-10s %s\n" "${iface%:}" "${addr%/*}"
+	                        found=1
+	                done < <(ip -o -4 addr show scope global)
+	        fi
 
 	        (( found )) || echo "No active connection"
 }
 
 # Show file in quick look
-function quick-look() {
-        (($# > 0)) && qlmanage -p $* &>/dev/null &
-}
+if [[ "$(uname)" == "Darwin" ]]; then
+        function quick-look() {
+                (($# > 0)) && qlmanage -p $* &>/dev/null &
+        }
+fi
 
 # Open man page in preview app
-preman() {
-        mandoc -T pdf "$(/usr/bin/man -w $@)" | open -fa Preview
-}
+if [[ "$(uname)" == "Darwin" ]]; then
+        preman() {
+                mandoc -T pdf "$(/usr/bin/man -w $@)" | open -fa Preview
+        }
+fi
 # Function to handle Git command suggestions
 copilot_git_suggest() {
         gh copilot suggest -t git "$@"
@@ -128,6 +143,12 @@ codex() {
 }
 
 # Fun
-flip() { echo -n "（╯°□°）╯ ┻━┻" |tee /dev/tty| pbcopy -selection clipboard; }
+flip() {
+        if command -v pbcopy >/dev/null 2>&1; then
+                echo -n "（╯°□°）╯ ┻━┻" | tee /dev/tty | pbcopy
+        else
+                echo -n "（╯°□°）╯ ┻━┻"
+        fi
+}
 
 # shrug() { echo -n "¯\_(ツ)_/¯" |tee /dev/tty| pbcopy -selection clipboard; }

--- a/.zshrc_custom/functions.zsh
+++ b/.zshrc_custom/functions.zsh
@@ -101,14 +101,14 @@ function myip() {
 # Show file in quick look
 if [[ "$(uname)" == "Darwin" ]]; then
         function quick-look() {
-                (($# > 0)) && qlmanage -p $* &>/dev/null &
+                (($# > 0)) && qlmanage -p "$@" &>/dev/null &
         }
 fi
 
 # Open man page in preview app
 if [[ "$(uname)" == "Darwin" ]]; then
         preman() {
-                mandoc -T pdf "$(/usr/bin/man -w $@)" | open -fa Preview
+                mandoc -T pdf "$(/usr/bin/man -w "$@")" | open -fa Preview
         }
 fi
 # Function to handle Git command suggestions

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Personal dotfiles managed with [yadm](https://yadm.io).
 
 ### New Machine
 
+This path is for normal interactive machines where applying dotfiles immediately
+is acceptable.
+
 ```bash
 # Install yadm
 brew install yadm  # macOS
@@ -16,8 +19,8 @@ yadm clone https://github.com/pevd950/dotfiles.git
 yadm bootstrap
 ```
 
-For operational infrastructure hosts, do not start with `yadm clone` and
-`yadm bootstrap`; use the staged Debian/Linux infrastructure path below.
+Operational infrastructure hosts should not start with `yadm clone` and
+`yadm bootstrap`; use the staged Debian/Linux infrastructure path below instead.
 
 ### Debian/Linux Infrastructure Hosts
 
@@ -25,9 +28,9 @@ Operational Linux hosts should start with review and validation, not immediate
 dotfile application. Debian hosts use `apt` packages; Homebrew-on-Linux is not a
 dependency for this repo.
 
-Minimal rollout prerequisites are `zsh` and `yadm`. Full local validation also
-needs `shellcheck`; the broader recommended package set below matches the shell
-features this repo enables on Debian.
+Minimal rollout prerequisites are `zsh` and `yadm`. The broader runtime package
+set below matches the shell features this repo enables on Debian. Full local
+validation also needs `shellcheck`.
 
 Recommended staged path:
 
@@ -36,11 +39,19 @@ Recommended staged path:
 mkdir -p ~/Developer
 git clone https://github.com/pevd950/dotfiles.git ~/Developer/dotfiles
 cd ~/Developer/dotfiles
-./scripts/check.sh
 
-# 2. Later, install prerequisites with apt after review.
+# Run validation now only if shellcheck and zsh are already available.
+if command -v shellcheck >/dev/null 2>&1 && command -v zsh >/dev/null 2>&1; then
+  ./scripts/check.sh
+fi
+
+# 2. Later, install runtime/adoption prerequisites with apt after review.
 sudo apt-get update
-sudo apt-get install -y zsh yadm stow fzf fd-find bat direnv shellcheck
+sudo apt-get install -y zsh yadm stow fzf fd-find bat direnv
+
+# Optional: install validation tooling before running the full local check.
+sudo apt-get install -y shellcheck
+./scripts/check.sh
 
 # 3. Back up existing shell and git config before yadm owns anything.
 mkdir -p ~/.dotfiles-backup

--- a/README.md
+++ b/README.md
@@ -16,6 +16,52 @@ yadm clone https://github.com/pevd950/dotfiles.git
 yadm bootstrap
 ```
 
+For operational infrastructure hosts, do not start with `yadm clone` and
+`yadm bootstrap`; use the staged Debian/Linux infrastructure path below.
+
+### Debian/Linux Infrastructure Hosts
+
+Operational Linux hosts should start with review and validation, not immediate
+dotfile application. Debian hosts use `apt` packages; Homebrew-on-Linux is not a
+dependency for this repo.
+
+Minimal rollout prerequisites are `zsh` and `yadm`. Full local validation also
+needs `shellcheck`; the broader recommended package set below matches the shell
+features this repo enables on Debian.
+
+Recommended staged path:
+
+```bash
+# 1. Review in a normal clone first. Do not use yadm yet.
+mkdir -p ~/Developer
+git clone https://github.com/pevd950/dotfiles.git ~/Developer/dotfiles
+cd ~/Developer/dotfiles
+./scripts/check.sh
+
+# 2. Later, install prerequisites with apt after review.
+sudo apt-get update
+sudo apt-get install -y zsh yadm stow fzf fd-find bat direnv shellcheck
+
+# 3. Back up existing shell and git config before yadm owns anything.
+mkdir -p ~/.dotfiles-backup
+cp -a ~/.bashrc ~/.profile ~/.gitconfig ~/.dotfiles-backup/ 2>/dev/null || true
+
+# 4. Clone with yadm only after conflicts are reviewed.
+yadm clone --no-bootstrap https://github.com/pevd950/dotfiles.git
+yadm status
+yadm alt
+
+# 5. Test zsh before making it the login shell.
+zsh -lic 'echo zsh startup ok'
+```
+
+Keep bash as the login shell until zsh startup is proven safe in interactive and
+remote sessions. Only consider `chsh` after confirming a rollback path.
+
+Do not run `yadm bootstrap` on infrastructure hosts until Linux support and
+host-specific conflicts have been reviewed. Bootstrap may create directories,
+install shell tooling when explicitly opted in, and link shared agent skills.
+
 ### Sync Existing Machine
 
 ```bash
@@ -94,8 +140,12 @@ This repo auto-configures Codespaces. GitHub runs `setup.sh` automatically (not 
 Shared environment bootstrap used by yadm bootstrap and Codespaces:
 - Oh My Zsh + plugins
 - Starship prompt
-- Homebrew installation (if needed) and `brew bundle --global`
-- Development tools via Brewfile plus Node version setup with nodenv
+- macOS: Homebrew installation (if needed) and `brew bundle --global`
+- Debian/Linux: prints apt package guidance by default and only installs apt
+  packages when `DOTFILES_INSTALL_LINUX_PACKAGES=1` is set
+- Debian/Linux: skips network shell installers by default; set
+  `DOTFILES_INSTALL_LINUX_SHELL_TOOLS=1` only after reviewing host impact
+- macOS development tools via Brewfile plus Node version setup with nodenv
 
 ### `.config/yadm/bootstrap`
 Full yadm bootstrap:

--- a/README.md
+++ b/README.md
@@ -19,65 +19,17 @@ yadm clone https://github.com/pevd950/dotfiles.git
 yadm bootstrap
 ```
 
-Operational infrastructure hosts should not start with `yadm clone` and
-`yadm bootstrap`; use the staged Debian/Linux infrastructure path below instead.
+### Linux
 
-### Debian/Linux Infrastructure Hosts
-
-Operational Linux hosts should start with review and validation, not immediate
-dotfile application. Debian hosts use `apt` packages; Homebrew-on-Linux is not a
-dependency for this repo.
-
-Minimal rollout prerequisites are `zsh` and `yadm`. The broader runtime package
-set below matches the shell features this repo enables on Debian. Full local
-validation also needs `shellcheck`.
-
-Recommended staged path:
+Linux hosts use their system package manager; Homebrew is only used on macOS.
 
 ```bash
-# 1. Review in a normal clone first. Do not use yadm yet.
-mkdir -p ~/Developer
-git clone https://github.com/pevd950/dotfiles.git ~/Developer/dotfiles
-cd ~/Developer/dotfiles
-
-# Run validation now only if shellcheck and zsh are already available.
-if command -v shellcheck >/dev/null 2>&1 && command -v zsh >/dev/null 2>&1; then
-  ./scripts/check.sh
-fi
-
-# 2. Later, install runtime/adoption prerequisites with apt after review.
-sudo apt-get update
-sudo apt-get install -y zsh yadm stow fzf fd-find bat direnv
-
-# Optional: install validation tooling before running the full local check.
-sudo apt-get install -y shellcheck
-./scripts/check.sh
-
-# 3. Back up existing files before yadm owns anything.
-mkdir -p ~/.dotfiles-backup
-cp -a ~/.bashrc ~/.profile ~/.gitconfig ~/.dotfiles-backup/ 2>/dev/null || true
-# Review and back up any existing paths yadm may manage, especially ~/.config/*,
-# ~/.zshrc_custom, ~/.codex, ~/.claude, and authenticated CLI config.
-
-# 4. Clone with yadm only after the likely managed paths are reviewed.
+sudo apt install yadm zsh
 yadm clone --no-bootstrap https://github.com/pevd950/dotfiles.git
-yadm status
-# Resolve or intentionally leave conflicts before generating alternates.
-# Existing authenticated CLI config under ~/.config should stay unmanaged unless
-# it is deliberately migrated into public-safe tracked files.
-yadm diff
-yadm alt
-
-# 5. Test zsh before making it the login shell.
-zsh -lic 'echo zsh startup ok'
 ```
 
-Keep bash as the login shell until zsh startup is proven safe in interactive and
-remote sessions. Only consider `chsh` after confirming a rollback path.
-
-Do not run `yadm bootstrap` on infrastructure hosts until Linux support and
-host-specific conflicts have been reviewed. Bootstrap may create directories,
-install shell tooling when explicitly opted in, and link shared agent skills.
+Review conflicts and bootstrap behavior on the target host before running
+`yadm bootstrap` or changing the login shell.
 
 ### Sync Existing Machine
 

--- a/README.md
+++ b/README.md
@@ -53,13 +53,19 @@ sudo apt-get install -y zsh yadm stow fzf fd-find bat direnv
 sudo apt-get install -y shellcheck
 ./scripts/check.sh
 
-# 3. Back up existing shell and git config before yadm owns anything.
+# 3. Back up existing files before yadm owns anything.
 mkdir -p ~/.dotfiles-backup
 cp -a ~/.bashrc ~/.profile ~/.gitconfig ~/.dotfiles-backup/ 2>/dev/null || true
+# Review and back up any existing paths yadm may manage, especially ~/.config/*,
+# ~/.zshrc_custom, ~/.codex, ~/.claude, and authenticated CLI config.
 
-# 4. Clone with yadm only after conflicts are reviewed.
+# 4. Clone with yadm only after the likely managed paths are reviewed.
 yadm clone --no-bootstrap https://github.com/pevd950/dotfiles.git
 yadm status
+# Resolve or intentionally leave conflicts before generating alternates.
+# Existing authenticated CLI config under ~/.config should stay unmanaged unless
+# it is deliberately migrated into public-safe tracked files.
+yadm diff
 yadm alt
 
 # 5. Test zsh before making it the login shell.

--- a/setup.sh
+++ b/setup.sh
@@ -169,7 +169,7 @@ detect_linux_id() {
   fi
 }
 
-debian_packages() {
+debian_runtime_packages() {
   cat <<'EOF'
 zsh
 yadm
@@ -178,6 +178,11 @@ fzf
 fd-find
 bat
 direnv
+EOF
+}
+
+debian_validation_packages() {
+  cat <<'EOF'
 shellcheck
 EOF
 }
@@ -189,9 +194,11 @@ linux_package_guidance() {
     debian|ubuntu)
       echo "Linux host detected: $linux_id"
       echo "Debian/Ubuntu hosts should use apt packages, not Homebrew-on-Linux."
-      echo "Suggested prerequisites:"
+      echo "Suggested runtime/adoption prerequisites:"
       echo "  sudo apt-get update"
-      echo "  sudo apt-get install -y $(debian_packages | tr '\n' ' ')"
+      echo "  sudo apt-get install -y $(debian_runtime_packages | tr '\n' ' ')"
+      echo "Suggested validation tooling:"
+      echo "  sudo apt-get install -y $(debian_validation_packages | tr '\n' ' ')"
       echo
       echo "No Linux packages were installed. Set DOTFILES_INSTALL_LINUX_PACKAGES=1 to opt in."
       ;;
@@ -214,7 +221,7 @@ install_debian_packages() {
 
   sudo apt-get update
   # shellcheck disable=SC2046
-  sudo apt-get install -y $(debian_packages)
+  sudo apt-get install -y $(debian_runtime_packages)
 }
 
 setup_packages() {

--- a/setup.sh
+++ b/setup.sh
@@ -199,8 +199,6 @@ linux_package_guidance() {
       echo "  sudo apt-get install -y $(debian_runtime_packages | tr '\n' ' ')"
       echo "Suggested validation tooling:"
       echo "  sudo apt-get install -y $(debian_validation_packages | tr '\n' ' ')"
-      echo
-      echo "No Linux packages were installed. Set DOTFILES_INSTALL_LINUX_PACKAGES=1 to opt in."
       ;;
     *)
       echo "Linux host detected: $linux_id"
@@ -214,14 +212,19 @@ install_debian_packages() {
     echo "apt-get is required for Debian package installation" >&2
     return 1
   fi
-  if ! command -v sudo &> /dev/null; then
-    echo "sudo is required for Debian package installation" >&2
-    return 1
+
+  local -a apt_cmd=()
+  if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
+    if ! command -v sudo &> /dev/null; then
+      echo "sudo is required for Debian package installation when not running as root" >&2
+      return 1
+    fi
+    apt_cmd=(sudo)
   fi
 
-  sudo apt-get update
+  "${apt_cmd[@]}" apt-get update
   # shellcheck disable=SC2046
-  sudo apt-get install -y $(debian_runtime_packages)
+  "${apt_cmd[@]}" apt-get install -y $(debian_runtime_packages)
 }
 
 setup_packages() {
@@ -240,6 +243,9 @@ setup_packages() {
           return 1
           ;;
       esac
+    else
+      echo
+      echo "No Linux packages were installed. Set DOTFILES_INSTALL_LINUX_PACKAGES=1 to opt in."
     fi
     return 0
   fi

--- a/setup.sh
+++ b/setup.sh
@@ -313,11 +313,12 @@ setup_shell() {
   fi
 
   if [[ "$platform" == "Linux" ]]; then
-    echo "Skipping network shell installers on Linux by default."
-    echo "Install zsh/yadm with the system package manager first, review conflicts, then opt in with DOTFILES_INSTALL_LINUX_SHELL_TOOLS=1 if desired."
     if [[ "${DOTFILES_INSTALL_LINUX_SHELL_TOOLS:-0}" != "1" ]]; then
+      echo "Skipping network shell installers on Linux by default."
+      echo "Install zsh/yadm with the system package manager first, review conflicts, then opt in with DOTFILES_INSTALL_LINUX_SHELL_TOOLS=1 if desired."
       return 0
     fi
+    echo "Installing Linux shell tools requested by DOTFILES_INSTALL_LINUX_SHELL_TOOLS=1."
     install_starship
     install_oh_my_zsh
   else

--- a/setup.sh
+++ b/setup.sh
@@ -159,8 +159,83 @@ detect_platform() {
   uname
 }
 
+detect_linux_id() {
+  if [ -r /etc/os-release ]; then
+    # shellcheck disable=SC1091
+    . /etc/os-release
+    echo "${ID:-linux}"
+  else
+    echo "linux"
+  fi
+}
+
+debian_packages() {
+  cat <<'EOF'
+zsh
+yadm
+stow
+fzf
+fd-find
+bat
+direnv
+shellcheck
+EOF
+}
+
+linux_package_guidance() {
+  local linux_id="$1"
+
+  case "$linux_id" in
+    debian|ubuntu)
+      echo "Linux host detected: $linux_id"
+      echo "Debian/Ubuntu hosts should use apt packages, not Homebrew-on-Linux."
+      echo "Suggested prerequisites:"
+      echo "  sudo apt-get update"
+      echo "  sudo apt-get install -y $(debian_packages | tr '\n' ' ')"
+      echo
+      echo "No Linux packages were installed. Set DOTFILES_INSTALL_LINUX_PACKAGES=1 to opt in."
+      ;;
+    *)
+      echo "Linux host detected: $linux_id"
+      echo "No package installation was attempted. Install zsh, yadm, stow, fzf, fd, bat, and direnv with the host package manager."
+      ;;
+  esac
+}
+
+install_debian_packages() {
+  if ! command -v apt-get &> /dev/null; then
+    echo "apt-get is required for Debian package installation" >&2
+    return 1
+  fi
+  if ! command -v sudo &> /dev/null; then
+    echo "sudo is required for Debian package installation" >&2
+    return 1
+  fi
+
+  sudo apt-get update
+  # shellcheck disable=SC2046
+  sudo apt-get install -y $(debian_packages)
+}
+
 setup_packages() {
   local platform="$1"
+
+  if [[ "$platform" == "Linux" ]]; then
+    local linux_id
+    linux_id="$(detect_linux_id)"
+    linux_package_guidance "$linux_id"
+
+    if [[ "${DOTFILES_INSTALL_LINUX_PACKAGES:-0}" == "1" ]]; then
+      case "$linux_id" in
+        debian|ubuntu) install_debian_packages ;;
+        *)
+          echo "Automatic package installation is only implemented for Debian/Ubuntu" >&2
+          return 1
+          ;;
+      esac
+    fi
+    return 0
+  fi
 
   if [[ "$platform" != "Darwin" ]]; then
     return 0
@@ -225,6 +300,11 @@ setup_shell() {
   fi
 
   if [[ "$platform" == "Linux" ]]; then
+    echo "Skipping network shell installers on Linux by default."
+    echo "Install zsh/yadm with the system package manager first, review conflicts, then opt in with DOTFILES_INSTALL_LINUX_SHELL_TOOLS=1 if desired."
+    if [[ "${DOTFILES_INSTALL_LINUX_SHELL_TOOLS:-0}" != "1" ]]; then
+      return 0
+    fi
     install_starship
     install_oh_my_zsh
   else


### PR DESCRIPTION
## Summary

- Keep Homebrew setup macOS-only and add Debian/Linux package guidance through `apt`.
- Make Linux package and shell-tool installation opt-in.
- Make zsh aliases, functions, and plugin loading safer across macOS and Debian.
- Add Debian command compatibility for `fd`, `bat`, and Docker Compose v2.
- Trim README Linux setup notes to the basics.

## Validation

- `./scripts/check.sh`
- `git diff --check`
- CI: `Validate dotfiles`

## Notes

Linux hosts should review local conflicts before running bootstrap or changing login shells.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shell startup and bootstrap behavior across macOS/Linux; while mostly gating/guarding, changes can affect interactive environments and package installation flow on Debian/Ubuntu if env flags are set.
> 
> **Overview**
> Improves cross-platform robustness by making `.zshrc` OS-aware: conditional sourcing of OS exports, conditional plugin enablement (e.g., `docker-compose`), guarded Oh My Zsh loading, and only initializing `starship` when installed.
> 
> Hardens custom aliases/functions to avoid errors on non-macOS and missing tools (e.g., gates `open`, `pbcopy`, VS Code, Copilot, Xcode helpers; adds Linux-friendly `myip`). Adds `debian-exports` to provide Debian command compatibility (`fd`/`bat` naming and Compose v2 shim).
> 
> Updates `setup.sh` and README to keep Homebrew macOS-only, print Linux apt guidance by default, and make Debian package installs (`DOTFILES_INSTALL_LINUX_PACKAGES`) and network shell installers (`DOTFILES_INSTALL_LINUX_SHELL_TOOLS`) explicitly opt-in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21ea63f74bcd266761ab0311cd1ec23fc5bb09d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OS-aware startup: conditional plugins, macOS-only features, and conditional prompt/init only when available
  * Optional Linux package installation and guided Debian/Ubuntu setup flow

* **Documentation**
  * Expanded setup instructions with Linux-specific guidance and environment toggles

* **Chores**
  * Tool- and OS-gated aliases/commands to avoid errors on unsupported systems
  * Graceful handling and messaging when components or tools are missing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->