### PR TITLE
Clarify notification retry guidance

### DIFF
--- a/.config/agent-skills/skills/actionbuddy-notify/SKILL.md
+++ b/.config/agent-skills/skills/actionbuddy-notify/SKILL.md
@@ -24,7 +24,8 @@ description: "Send the configured user a concise local notification through the 
    - `python3 "$HOME/.config/agent-skills/skills/actionbuddy-notify/scripts/send_notification.py" --check --message "For the user from Codex: test notification. Context: validating ActionBuddy relay. Next step: none."`
 5. Send only after validation succeeds:
    - `python3 "$HOME/.config/agent-skills/skills/actionbuddy-notify/scripts/send_notification.py" --send --message "For the user from Codex: test notification. Context: validating ActionBuddy relay. Next step: none."`
-6. Report the redacted result back to the user.
+6. If delivery fails with a read-only database, Operation not permitted, or Shortcuts access error in a sandboxed session, retry the same validated message with the session's approved filesystem or GUI escalation mechanism when policy permits.
+7. Report the redacted result back to the user.
 
 ## Message Shape
 - Prefer one compact paragraph.

--- a/.config/agent-skills/skills/actionbuddy-notify/SKILL.md
+++ b/.config/agent-skills/skills/actionbuddy-notify/SKILL.md
@@ -24,8 +24,9 @@ description: "Send the configured user a concise local notification through the 
    - `python3 "$HOME/.config/agent-skills/skills/actionbuddy-notify/scripts/send_notification.py" --check --message "For the user from Codex: test notification. Context: validating ActionBuddy relay. Next step: none."`
 5. Send only after validation succeeds:
    - `python3 "$HOME/.config/agent-skills/skills/actionbuddy-notify/scripts/send_notification.py" --send --message "For the user from Codex: test notification. Context: validating ActionBuddy relay. Next step: none."`
-6. If delivery fails with a read-only database, Operation not permitted, or Shortcuts access error in a sandboxed session, retry the same validated message with the session's approved filesystem or GUI escalation mechanism when policy permits.
-7. Report the redacted result back to the user.
+6. If delivery fails with a readonly database, Operation not permitted, or Shortcuts access error in a sandboxed session, retry the same validated message with the session's approved local-automation escalation mechanism when policy permits.
+7. If delivery still fails, stop and report a concise redacted blocker instead of probing Shortcuts databases, processes, clipboard state, or app internals unless the user explicitly asked to debug the relay.
+8. Report the redacted result back to the user.
 
 ## Message Shape
 - Prefer one compact paragraph.
@@ -36,4 +37,5 @@ description: "Send the configured user a concise local notification through the 
 ## Notes
 - ActionBuddy's shortcut action currently hangs when its body is connected to dynamic Shortcut Input or Clipboard variables through the CLI runner.
 - The reliable path is to patch the shortcut body as a literal string before running the shortcut.
+- Readonly database and Shortcuts helper errors usually mean the notification was not delivered; treat them as delivery blockers unless a permitted retry succeeds.
 - Do not include secrets in notification text; the message is briefly stored in the local Shortcuts database while being sent.

--- a/.config/agent-skills/skills/poke-notify/SKILL.md
+++ b/.config/agent-skills/skills/poke-notify/SKILL.md
@@ -38,7 +38,8 @@ description: "Send the configured user a concise handoff message through Poke's 
 8. Send only after the check passes:
    - `scripts/send_notification.py --send --message "For the user from Codex: work on the notification skill is ready for review. Context: updated the skill so agents include handoff details and click-ready PR or issue links. Links: PR https://github.com/org/repo/pull/123 | Issue https://github.com/org/repo/issues/456. Next step: review the wording and merge if it looks right. No action needed from you beyond relaying this message."`
 9. If delivery fails with a DNS, timeout, or network-access error in a sandboxed session, retry the same validated message with the session's approved network-escalation mechanism when policy permits.
-10. Report only the redacted result back to the user.
+10. If delivery still fails, stop and report a concise redacted blocker instead of repeatedly retrying or debugging unrelated network state.
+11. Report only the redacted result back to the user.
 
 ## Message content rules
 - Prefer one compact paragraph over multiple short fragments.
@@ -50,6 +51,7 @@ description: "Send the configured user a concise handoff message through Poke's 
 ## Notes
 - Auth uses `Authorization: Bearer $POKE_API_KEY`.
 - The helper script performs schema validation before any real delivery.
+- DNS or connection errors usually mean the notification was not delivered; treat them as delivery blockers unless a permitted retry succeeds.
 - The canonical skill lives in `~/.config/agent-skills/skills/poke-notify/`.
 - Provider-specific locations should use symlinks to this shared folder.
 - Avoid imperative messages like `go to the laptop` with no context; they make Poke infer the wrong role.

--- a/.config/agent-skills/skills/poke-notify/SKILL.md
+++ b/.config/agent-skills/skills/poke-notify/SKILL.md
@@ -19,6 +19,7 @@ description: "Send the configured user a concise handoff message through Poke's 
 - Never print, store, commit, log, or echo the resolved secret value.
 - The payload must include a non-empty `message` field.
 - Include direct URLs when they exist and are useful, such as PRs, issues, CI runs, docs, designs, or other hosted review artifacts.
+- The helper makes an outbound HTTPS request and may need network permission in restricted sandboxes.
 
 ## Workflow
 1. Confirm the message text is appropriate, concise, and contains the useful handoff context.
@@ -36,7 +37,8 @@ description: "Send the configured user a concise handoff message through Poke's 
    - `scripts/send_notification.py --check --message "For the user from Codex: work on the notification skill is ready for review. Context: updated the skill so agents include handoff details and click-ready PR or issue links. Links: PR https://github.com/org/repo/pull/123 | Issue https://github.com/org/repo/issues/456. Next step: review the wording and merge if it looks right. No action needed from you beyond relaying this message."`
 8. Send only after the check passes:
    - `scripts/send_notification.py --send --message "For the user from Codex: work on the notification skill is ready for review. Context: updated the skill so agents include handoff details and click-ready PR or issue links. Links: PR https://github.com/org/repo/pull/123 | Issue https://github.com/org/repo/issues/456. Next step: review the wording and merge if it looks right. No action needed from you beyond relaying this message."`
-9. Report only the redacted result back to the user.
+9. If delivery fails with a DNS, timeout, or network-access error in a sandboxed session, retry the same validated message with the session's approved network-escalation mechanism when policy permits.
+10. Report only the redacted result back to the user.
 
 ## Message content rules
 - Prefer one compact paragraph over multiple short fragments.


### PR DESCRIPTION
## Summary
- clarify that Poke notification delivery may need network permission in restricted sandboxes
- bound Poke DNS/network failures to one permitted retry, then a redacted blocker
- clarify that ActionBuddy Shortcuts/readonly database failures should use one permitted local-automation retry, then stop instead of probing internals

## Validation
- validated touched SKILL.md frontmatter fences, name, and description fields
- scanned touched skills for private host names and personal paths

## Evidence
- recent Codex sessions showed repeated notification delivery failures from network/DNS restrictions for Poke and readonly Shortcuts database access for ActionBuddy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only changes that adjust operational guidance for handling delivery errors (network or Shortcuts permissions) without altering code paths.
> 
> **Overview**
> **Clarifies failure-handling guidance for notification relays.**
> 
> Updates `actionbuddy-notify` to treat readonly Shortcuts DB / permission errors as delivery blockers, allowing *one policy-approved local-automation retry* in sandboxed sessions and then stopping with a concise redacted blocker.
> 
> Updates `poke-notify` to call out potential sandbox network permission needs, allow *one policy-approved network retry* on DNS/timeout/network-access failures, and then stop with a concise redacted blocker (also noting these errors usually mean non-delivery).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c93455503d3039646fcb2c58539a1438babb448. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Improved notification delivery error messages and reporting for sandbox, permission, and network-related failures
* Enhanced retry behavior guidelines for consistent handling when delivery issues occur
* Clarified error categorization to distinguish between recoverable and unrecoverable delivery failures

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/17?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->