### PR TITLE
Add email draft handoff skill

### DIFF
--- a/.config/agent-skills/skills/email-draft-handoff/SKILL.md
+++ b/.config/agent-skills/skills/email-draft-handoff/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: email-draft-handoff
+description: Create user-facing email draft handoffs with a visible prefilled mailto link plus plain draft text; use whenever drafting an email for the user in Todoist, Craft, notes, or chat, optionally alongside Apple Mail draft tooling.
+---
+
+# Email Draft Handoff
+
+Use this skill whenever drafting an email for the user unless they explicitly ask for another format.
+
+## Default Pattern
+
+1. Build a prefilled `mailto:` URL with recipient, subject, and body.
+2. Put a visible Markdown link near the top of the handoff:
+
+```markdown
+[Open prefilled email](mailto:...)
+```
+
+3. Include the plain draft text below the link as fallback.
+4. If adding to Todoist, Craft, or another task/note surface, put the link before the plain draft.
+5. Never send the email automatically.
+
+## Optional Apple Mail Drafts
+
+Apple Mail `.eml` or draft creation can be supplemental when useful, especially for rich text or desktop review. It does not replace the visible `mailto:` link.
+
+If both are used, report both:
+
+- the visible `mailto:` link was added where the user can tap it
+- the local Mail draft was created/opened, if applicable
+
+## URL Encoding
+
+Use the helper script to avoid malformed links:
+
+```bash
+python3 "$HOME/.config/agent-skills/skills/email-draft-handoff/scripts/build_mailto.py" \
+  --to "recipient@example.com" \
+  --subject "Subject here" \
+  --body-file /path/to/body.txt
+```
+
+The script prints the `mailto:` URL.
+
+For short one-off drafts, it is also acceptable to use a language standard library such as Python `urllib.parse.quote`.
+
+## Long Drafts
+
+Very long `mailto:` URLs may not open reliably in every app. If the draft is long:
+
+- keep the `mailto:` body concise, or include only the opening and key fields
+- include the complete plain draft below the link
+- optionally create/open a local Mail draft as a supplemental artifact
+
+## Existing Threads
+
+When replying to an existing support thread:
+
+- preserve the ticket/reference number in the subject when known
+- link to the source email separately when a `message://...` link is available
+- still use the `mailto:` link for the prefilled draft handoff
+

--- a/.config/agent-skills/skills/email-draft-handoff/agents/openai.yaml
+++ b/.config/agent-skills/skills/email-draft-handoff/agents/openai.yaml
@@ -1,0 +1,4 @@
+name: email-draft-handoff
+description: Create tappable prefilled email draft links with plain-text fallback.
+entrypoint: SKILL.md
+

--- a/.config/agent-skills/skills/email-draft-handoff/scripts/build_mailto.py
+++ b/.config/agent-skills/skills/email-draft-handoff/scripts/build_mailto.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+import argparse
+from pathlib import Path
+from urllib.parse import quote
+
+
+def read_body(args):
+    if args.body_file:
+        return Path(args.body_file).read_text()
+    return args.body or ""
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Build a URL-encoded mailto link.")
+    parser.add_argument("--to", required=True, help="Recipient email address or comma-separated addresses.")
+    parser.add_argument("--subject", default="", help="Email subject.")
+    parser.add_argument("--body", default="", help="Email body text.")
+    parser.add_argument("--body-file", help="Path to a UTF-8 text file containing the email body.")
+    args = parser.parse_args()
+
+    body = read_body(args)
+    params = []
+    if args.subject:
+        params.append("subject=" + quote(args.subject))
+    if body:
+        params.append("body=" + quote(body))
+
+    url = "mailto:" + quote(args.to, safe="@,")
+    if params:
+        url += "?" + "&".join(params)
+    print(url)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add an email-draft-handoff skill for user-facing draft email handoffs
- include a visible prefilled mailto link plus plain-text fallback as the default pattern
- add a small helper for URL-encoding mailto subject/body values

## Validation
- ./scripts/check.sh
- python3 .config/agent-skills/skills/email-draft-handoff/scripts/build_mailto.py --to support@example.com --subject 'Ticket #123' --body $'Hi\nThanks'
- ruby frontmatter parse for SKILL.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new agent skill and a standalone helper script without modifying existing runtime logic or sensitive data flows.
> 
> **Overview**
> Adds a new `email-draft-handoff` skill that standardizes email drafting handoffs by providing a **tappable prefilled `mailto:` link** plus a **plain-text draft fallback**, with guidance for long drafts and optional Apple Mail artifacts.
> 
> Includes a small `build_mailto.py` CLI helper to URL-encode recipients/subject/body (optionally reading the body from a file) to reduce malformed `mailto:` links, and registers the skill via an `agents/openai.yaml` entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04b1c52106eae14064b612beee58e7f7de54b791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->