### PR TITLE
Add Craft API skill

### DIFF
--- a/.config/agent-skills/skills/craft-api/SKILL.md
+++ b/.config/agent-skills/skills/craft-api/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: craft-api
+description: Use Craft through its HTTP API as a durable fallback when Craft MCP is unavailable, expired, or impractical on headless hosts. Use for reading, searching, creating, updating, moving, or deleting Craft documents, blocks, collections, comments, uploads, and connection metadata via CRAFT_API_BASE_URL and CRAFT_API_KEY.
+---
+
+# Craft API
+
+Use this skill when Craft MCP is missing, unauthenticated, expired, or awkward to use from a headless host. Prefer Craft MCP when it is available because it provides higher-level commands, but treat the API as the durable fallback for real read/write work.
+
+## Environment
+
+Assume the shell environment is already loaded. Before calling the API, verify that the required variables are present:
+
+```shell
+test -n "$CRAFT_API_BASE_URL"
+test -n "$CRAFT_API_KEY"
+```
+
+Expected local-only variables:
+
+- `CRAFT_API_BASE_URL`: connection URL ending in `/api/v1`
+- `CRAFT_API_KEY`: private key for that connection
+
+If those variables are missing, ask the user to add them to a host-local ignored secrets file or shell startup path. Do not assume a specific home directory, dotfiles layout, shell, or secrets-file path.
+
+Never write API keys, private Craft links, user-specific paths, or space IDs into tracked skill files, PR bodies, Craft demo pages, or logs.
+
+## Auth
+
+Observed behavior: Craft API connections may succeed with `Authorization: Bearer $CRAFT_API_KEY` even when docs or examples mention `x-craft-api-key`. Try bearer auth first; keep `x-craft-api-key` as a fallback for connections that require it.
+
+Use the bundled helper for routine calls because it centralizes auth and avoids printing secrets. Let `SKILL_DIR` mean the directory containing this `SKILL.md`, then run:
+
+```shell
+python3 "$SKILL_DIR/scripts/craft_api.py" GET /connection
+python3 "$SKILL_DIR/scripts/craft_api.py" GET /documents
+```
+
+Resolve the script relative to this `SKILL.md` file. Do not assume the current working directory is the skill folder, and do not hard-code a user's home path.
+
+For manual `curl`, prefer:
+
+```shell
+curl -fsS \
+  -H "Accept: application/json" \
+  -H "Authorization: Bearer $CRAFT_API_KEY" \
+  "$CRAFT_API_BASE_URL/documents"
+```
+
+If writing your own HTTP client, set a normal `User-Agent`. Python `urllib`'s default user-agent was blocked by Craft/Cloudflare with error 1010, while `curl` and the helper script's curl-like user-agent worked.
+
+## Workflow
+
+1. Probe `GET /connection` and confirm the expected space/timezone.
+2. Discover targets with `GET /documents`, `GET /documents/search`, or `GET /blocks?id=<blockId>`.
+3. Read before writing. Capture target block IDs and enough current content to roll back.
+4. Make the smallest mutation that satisfies the request.
+5. Read back the changed block, document, collection, or comment anchor.
+6. Return the Craft app deeplink from `/connection.urlTemplates` or the MCP/tool output when available.
+
+## Endpoint Map
+
+Common read endpoints:
+
+- `GET /connection`: space metadata and URL templates.
+- `GET /documents`: documents exposed to the API connection.
+- `GET /blocks?id=<id>&maxDepth=<n>`: block/document content.
+- `GET /documents/search?include=<term>`: cross-document search.
+- `GET /blocks/search?documentId=<id>&pattern=<regex>`: within-document search.
+- `GET /collections`: collection discovery.
+- `GET /collections/{collectionId}/schema`: schema for row validation.
+- `GET /collections/{collectionId}/items`: collection rows.
+
+Common write endpoints:
+
+- `POST /blocks`: insert structured blocks or markdown at `pageId`/`siblingId`.
+- `PUT /blocks`: update text/block fields.
+- `PUT /blocks/move`: reorder or move blocks.
+- `DELETE /blocks`: delete specified blocks.
+- `POST /collections/{collectionId}/items`: add rows.
+- `PUT /collections/{collectionId}/items`: update rows.
+- `DELETE /collections/{collectionId}/items`: delete rows.
+- `POST /comments`: add anchored comments. Treat as experimental and verify.
+- `POST /upload`: upload and insert files. Treat as experimental and verify.
+
+## Formatting Notes
+
+- Markdown insertion is sensitive to newline shape. In shell commands, pass real newlines, not literal `\n` sequences. Read back the document and fix escaped `\n` artifacts.
+- For multiple list items, insert them together with real single newlines. If updating a single existing list item to multiple items fails, insert the replacement list after a nearby sibling, then delete the old block.
+- For code blocks, prefer structured API blocks with `type: "code"`, `rawCode`, and `language`. Markdown code fences may round-trip as inline code in some MCP paths.
+- Craft-specific markdown tokens seen working: `<callout>...</callout>`, blockquotes, task lists, toggles, headings, nested lists, links, and washi separators through MCP styling.
+- Inline highlights use Craft's named color set, not arbitrary hex. Known accepted names include `yellow`, `green`, `mint`, `cyan`, `blue`, `purple`, `pink`, `red`, `gray`, and gradient variants such as `gradient-blue`.
+- Shell expansion can leak secrets into Craft if a payload is built with unescaped `$CRAFT_API_KEY` or `$CRAFT_API_BASE_URL`. Use single quotes, JSON arguments, or helper scripts so examples remain literal.
+- API client defaults matter. Avoid default Python `urllib` headers; set a user agent explicitly.
+
+## Collections
+
+- Read schema before adding or updating rows.
+- Select properties may reject new values unless the request explicitly allows creating options. Only use `allowNewSelectOptions` when the user intends to add new option values.
+- Collection items can have page bodies. Use that for details while keeping row properties compact.
+- Verify rows with `GET /collections/{collectionId}/items` after mutation.
+
+## Safety
+
+- Treat the API as production access to real Craft data.
+- Safe tests: reads, creating clearly disposable content, or reversible writes with immediate verification.
+- Avoid permanent deletes unless explicitly asked. If deleting test content, first confirm the target IDs were created by the current run.
+- If an API response contradicts documentation, preserve the observed behavior in the task notes or skill update. Known drift: `Bearer` auth has worked where `x-craft-api-key` returned `401`.

--- a/.config/agent-skills/skills/craft-api/agents/openai.yaml
+++ b/.config/agent-skills/skills/craft-api/agents/openai.yaml
@@ -1,0 +1,3 @@
+display_name: Craft API
+short_description: Use Craft over HTTP when MCP is unavailable.
+default_prompt: Use the Craft API skill to read or update Craft through the configured API connection, with readback verification.

--- a/.config/agent-skills/skills/craft-api/agents/openai.yaml
+++ b/.config/agent-skills/skills/craft-api/agents/openai.yaml
@@ -1,4 +1,7 @@
 interface:
   display_name: Craft API
   short_description: Use Craft over HTTP when MCP is unavailable.
-  default_prompt: Use the Craft API skill to read or update Craft through the configured API connection, with readback verification.
+  default_prompt: Use $craft-api to read or update Craft through the configured API connection, with readback verification.
+
+policy:
+  allow_implicit_invocation: true

--- a/.config/agent-skills/skills/craft-api/agents/openai.yaml
+++ b/.config/agent-skills/skills/craft-api/agents/openai.yaml
@@ -1,3 +1,4 @@
-display_name: Craft API
-short_description: Use Craft over HTTP when MCP is unavailable.
-default_prompt: Use the Craft API skill to read or update Craft through the configured API connection, with readback verification.
+interface:
+  display_name: Craft API
+  short_description: Use Craft over HTTP when MCP is unavailable.
+  default_prompt: Use the Craft API skill to read or update Craft through the configured API connection, with readback verification.

--- a/.config/agent-skills/skills/craft-api/scripts/craft_api.py
+++ b/.config/agent-skills/skills/craft-api/scripts/craft_api.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+import urllib.parse
+import urllib.request
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Call the Craft API using local env auth.")
+    parser.add_argument("method", choices=["GET", "POST", "PUT", "DELETE"])
+    parser.add_argument("path", help="API path, such as /documents or /blocks")
+    parser.add_argument("--query", action="append", default=[], help="Query pair key=value; may repeat")
+    parser.add_argument("--json", dest="json_body", help="Inline JSON request body")
+    parser.add_argument("--json-file", help="File containing JSON request body")
+    parser.add_argument("--accept", default="application/json")
+    parser.add_argument("--auth", choices=["bearer", "x-craft-api-key"], default="bearer")
+    args = parser.parse_args()
+
+    base_url = os.environ.get("CRAFT_API_BASE_URL", "").rstrip("/")
+    api_key = os.environ.get("CRAFT_API_KEY", "")
+    if not base_url or not api_key:
+        print("CRAFT_API_BASE_URL and CRAFT_API_KEY must be set", file=sys.stderr)
+        return 2
+
+    path = args.path if args.path.startswith("/") else f"/{args.path}"
+    query_pairs = []
+    for item in args.query:
+        if "=" not in item:
+            print(f"--query must be key=value: {item}", file=sys.stderr)
+            return 2
+        key, value = item.split("=", 1)
+        query_pairs.append((key, value))
+    query = urllib.parse.urlencode(query_pairs, doseq=True)
+    url = f"{base_url}{path}"
+    if query:
+        url = f"{url}?{query}"
+
+    body = None
+    if args.json_body and args.json_file:
+        print("Use --json or --json-file, not both", file=sys.stderr)
+        return 2
+    if args.json_body:
+        body = json.dumps(json.loads(args.json_body)).encode("utf-8")
+    elif args.json_file:
+        with open(args.json_file, "rb") as handle:
+            body = handle.read()
+
+    headers = {
+        "Accept": args.accept,
+        "User-Agent": "curl/8.7.1",
+    }
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+    if args.auth == "bearer":
+        headers["Authorization"] = f"Bearer {api_key}"
+    else:
+        headers["x-craft-api-key"] = api_key
+
+    request = urllib.request.Request(url, data=body, headers=headers, method=args.method)
+    try:
+        with urllib.request.urlopen(request) as response:
+            sys.stdout.buffer.write(response.read())
+            if not sys.stdout.isatty():
+                sys.stdout.write("\n")
+    except urllib.error.HTTPError as error:
+        sys.stderr.write(f"Craft API returned HTTP {error.code}\n")
+        detail = error.read().decode("utf-8", errors="replace")
+        if detail:
+            sys.stderr.write(detail[:2000] + "\n")
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.config/agent-skills/skills/craft-api/scripts/craft_api.py
+++ b/.config/agent-skills/skills/craft-api/scripts/craft_api.py
@@ -10,6 +10,9 @@ import urllib.parse
 import urllib.request
 
 
+MAX_TIMEOUT_SECONDS = 300.0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description="Call the Craft API using local env auth.")
     parser.add_argument("method", choices=["GET", "POST", "PUT", "DELETE"])
@@ -21,8 +24,8 @@ def main() -> int:
     parser.add_argument("--auth", choices=["bearer", "x-craft-api-key"], default="bearer")
     parser.add_argument("--timeout", type=float, default=30.0, help="Request timeout in seconds")
     args = parser.parse_args()
-    if not math.isfinite(args.timeout) or args.timeout <= 0:
-        print("--timeout must be a positive finite number", file=sys.stderr)
+    if not math.isfinite(args.timeout) or args.timeout <= 0 or args.timeout > MAX_TIMEOUT_SECONDS:
+        print(f"--timeout must be a positive finite number <= {MAX_TIMEOUT_SECONDS:g}", file=sys.stderr)
         return 2
 
     base_url = os.environ.get("CRAFT_API_BASE_URL", "").rstrip("/")
@@ -65,8 +68,8 @@ def main() -> int:
     elif args.json_file:
         try:
             with open(args.json_file, "rb") as handle:
-                body = handle.read()
-            json.loads(body)
+                raw_body = handle.read()
+            body = json.dumps(json.loads(raw_body)).encode("utf-8")
         except OSError as error:
             print(f"Cannot read --json-file: {error}", file=sys.stderr)
             return 2

--- a/.config/agent-skills/skills/craft-api/scripts/craft_api.py
+++ b/.config/agent-skills/skills/craft-api/scripts/craft_api.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import os
+import math
 import sys
 import urllib.error
 import urllib.parse
@@ -19,11 +20,18 @@ def main() -> int:
     parser.add_argument("--auth", choices=["bearer", "x-craft-api-key"], default="bearer")
     parser.add_argument("--timeout", type=float, default=30.0, help="Request timeout in seconds")
     args = parser.parse_args()
+    if not math.isfinite(args.timeout) or args.timeout <= 0:
+        print("--timeout must be a positive finite number", file=sys.stderr)
+        return 2
 
     base_url = os.environ.get("CRAFT_API_BASE_URL", "").rstrip("/")
     api_key = os.environ.get("CRAFT_API_KEY", "")
     if not base_url or not api_key:
         print("CRAFT_API_BASE_URL and CRAFT_API_KEY must be set", file=sys.stderr)
+        return 2
+    parsed_base_url = urllib.parse.urlsplit(base_url)
+    if parsed_base_url.scheme not in {"http", "https"} or not parsed_base_url.netloc:
+        print("CRAFT_API_BASE_URL must be an absolute http(s) URL", file=sys.stderr)
         return 2
 
     path = args.path if args.path.startswith("/") else f"/{args.path}"
@@ -57,6 +65,9 @@ def main() -> int:
             json.loads(body)
         except OSError as error:
             print(f"Cannot read --json-file: {error}", file=sys.stderr)
+            return 2
+        except UnicodeDecodeError as error:
+            print(f"Invalid UTF-8 in --json-file: {error}", file=sys.stderr)
             return 2
         except json.JSONDecodeError as error:
             print(f"Invalid JSON in --json-file: {error}", file=sys.stderr)

--- a/.config/agent-skills/skills/craft-api/scripts/craft_api.py
+++ b/.config/agent-skills/skills/craft-api/scripts/craft_api.py
@@ -37,7 +37,8 @@ def main() -> int:
     query = urllib.parse.urlencode(query_pairs, doseq=True)
     url = f"{base_url}{path}"
     if query:
-        url = f"{url}?{query}"
+        separator = "&" if urllib.parse.urlsplit(url).query else "?"
+        url = f"{url}{separator}{query}"
 
     body = None
     if args.json_body and args.json_file:
@@ -86,6 +87,9 @@ def main() -> int:
             sys.stderr.write(detail[:2000] + "\n")
         return 1
     except urllib.error.URLError as error:
+        if isinstance(error.reason, TimeoutError):
+            sys.stderr.write(f"Craft API request timed out after {args.timeout:g}s\n")
+            return 1
         sys.stderr.write(f"Craft API request failed: {error.reason}\n")
         return 1
     except TimeoutError:

--- a/.config/agent-skills/skills/craft-api/scripts/craft_api.py
+++ b/.config/agent-skills/skills/craft-api/scripts/craft_api.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import argparse
+import http.client
 import json
 import os
 import math
@@ -28,6 +29,9 @@ def main() -> int:
     api_key = os.environ.get("CRAFT_API_KEY", "")
     if not base_url or not api_key:
         print("CRAFT_API_BASE_URL and CRAFT_API_KEY must be set", file=sys.stderr)
+        return 2
+    if any(ord(ch) < 32 or ord(ch) == 127 for ch in api_key):
+        print("CRAFT_API_KEY contains invalid control characters", file=sys.stderr)
         return 2
     parsed_base_url = urllib.parse.urlsplit(base_url)
     if parsed_base_url.scheme not in {"http", "https"} or not parsed_base_url.netloc:
@@ -106,6 +110,9 @@ def main() -> int:
     except TimeoutError:
         sys.stderr.write(f"Craft API request timed out after {args.timeout:g}s\n")
         return 1
+    except (ValueError, http.client.InvalidURL) as error:
+        sys.stderr.write(f"Craft API request is invalid: {error}\n")
+        return 2
 
     return 0
 

--- a/.config/agent-skills/skills/craft-api/scripts/craft_api.py
+++ b/.config/agent-skills/skills/craft-api/scripts/craft_api.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import os
 import sys
+import urllib.error
 import urllib.parse
 import urllib.request
 
@@ -16,6 +17,7 @@ def main() -> int:
     parser.add_argument("--json-file", help="File containing JSON request body")
     parser.add_argument("--accept", default="application/json")
     parser.add_argument("--auth", choices=["bearer", "x-craft-api-key"], default="bearer")
+    parser.add_argument("--timeout", type=float, default=30.0, help="Request timeout in seconds")
     args = parser.parse_args()
 
     base_url = os.environ.get("CRAFT_API_BASE_URL", "").rstrip("/")
@@ -42,10 +44,22 @@ def main() -> int:
         print("Use --json or --json-file, not both", file=sys.stderr)
         return 2
     if args.json_body:
-        body = json.dumps(json.loads(args.json_body)).encode("utf-8")
+        try:
+            body = json.dumps(json.loads(args.json_body)).encode("utf-8")
+        except json.JSONDecodeError as error:
+            print(f"Invalid JSON for --json: {error}", file=sys.stderr)
+            return 2
     elif args.json_file:
-        with open(args.json_file, "rb") as handle:
-            body = handle.read()
+        try:
+            with open(args.json_file, "rb") as handle:
+                body = handle.read()
+            json.loads(body)
+        except OSError as error:
+            print(f"Cannot read --json-file: {error}", file=sys.stderr)
+            return 2
+        except json.JSONDecodeError as error:
+            print(f"Invalid JSON in --json-file: {error}", file=sys.stderr)
+            return 2
 
     headers = {
         "Accept": args.accept,
@@ -60,15 +74,22 @@ def main() -> int:
 
     request = urllib.request.Request(url, data=body, headers=headers, method=args.method)
     try:
-        with urllib.request.urlopen(request) as response:
-            sys.stdout.buffer.write(response.read())
-            if not sys.stdout.isatty():
+        with urllib.request.urlopen(request, timeout=args.timeout) as response:
+            payload = response.read()
+            sys.stdout.buffer.write(payload)
+            if sys.stdout.isatty() and not payload.endswith(b"\n"):
                 sys.stdout.write("\n")
     except urllib.error.HTTPError as error:
         sys.stderr.write(f"Craft API returned HTTP {error.code}\n")
         detail = error.read().decode("utf-8", errors="replace")
         if detail:
             sys.stderr.write(detail[:2000] + "\n")
+        return 1
+    except urllib.error.URLError as error:
+        sys.stderr.write(f"Craft API request failed: {error.reason}\n")
+        return 1
+    except TimeoutError:
+        sys.stderr.write(f"Craft API request timed out after {args.timeout:g}s\n")
         return 1
 
     return 0


### PR DESCRIPTION
## Summary
- add a reusable Craft API fallback skill for headless or MCP-unavailable hosts
- include a small env-based helper script for Craft HTTP API calls
- document observed auth, formatting, collection, and safety gotchas from live testing

## Validation
- ./scripts/check.sh
- SKILL.md frontmatter parse
- no private paths, Craft deeplinks, endpoint IDs, or API keys in the skill folder
- live GET /connection through the helper with local env sourced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new implicitly-invokable skill and CLI helper capable of making authenticated read/write requests to the Craft API, so misconfiguration or unintended invocation could impact real documents.
> 
> **Overview**
> Adds a new `craft-api` skill that documents how to use Craft’s HTTP API as a fallback when MCP is unavailable, including endpoint guidance, formatting gotchas, and safety practices to avoid leaking secrets or making irreversible changes.
> 
> Includes an `openai.yaml` agent configuration enabling implicit invocation, plus a small Python helper (`scripts/craft_api.py`) that performs env-based authenticated API requests (Bearer or `x-craft-api-key`), supports query params and JSON bodies, sets a curl-like user agent, and provides basic input validation and error reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e29e3706e4ffb81fe6fda7a0ee396478bebb2e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->