### PR TITLE
Add Raindrop MCP skill

### DIFF
--- a/.config/agent-skills/skills/raindrop-mcp/SKILL.md
+++ b/.config/agent-skills/skills/raindrop-mcp/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: raindrop-mcp
+description: Work with Raindrop.io bookmarks through the official remote MCP endpoint, using a direct JSON-RPC helper when Codex does not expose the Raindrop MCP tool namespace. Use for verifying Raindrop access, searching bookmarks, reading bookmark content, inspecting collections/tags/highlights, and carefully managing bookmark metadata when explicitly requested.
+---
+
+# Raindrop MCP
+
+## Core Rules
+
+- Use the official Raindrop.io MCP endpoint directly when `mcp__raindrop__...` tools are not exposed in the current session:
+
+```text
+https://api.raindrop.io/rest/v2/ai/mcp
+```
+
+- Source the host's local shell exports before reads when `RAINDROP_ACCESS_TOKEN` is not already available:
+
+```bash
+source /path/to/local/exports
+```
+
+- Let `SKILL_DIR` mean the directory containing this `SKILL.md`. Resolve the helper relative to the skill file; do not hard-code a user's home path.
+
+- Prove access with a live read before claiming Raindrop works:
+
+```bash
+python3 "$SKILL_DIR/scripts/raindrop_mcp.py" call fetch_current_user
+```
+
+- Treat `codex mcp list` as configuration-only. It does not prove Raindrop tools are callable in the current Codex session.
+- Prefer read-only operations. Do not create, update, delete, merge, or retag bookmarks/collections/highlights unless the user explicitly asks for that mutation.
+- For mutating operations, first read the affected bookmark, collection, tag, or highlight and state the exact object that will change.
+
+## Common Reads
+
+List available MCP tools:
+
+```bash
+python3 "$SKILL_DIR/scripts/raindrop_mcp.py" tools
+```
+
+Fetch current account/library stats:
+
+```bash
+python3 "$SKILL_DIR/scripts/raindrop_mcp.py" call fetch_current_user
+```
+
+Search bookmarks:
+
+```bash
+python3 "$SKILL_DIR/scripts/raindrop_mcp.py" call find_bookmarks '{"query":"swift concurrency","limit":10}'
+```
+
+Fetch bookmark content:
+
+```bash
+python3 "$SKILL_DIR/scripts/raindrop_mcp.py" call fetch_bookmark_content '{"bookmark_id":123456}'
+```
+
+Inspect organization:
+
+```bash
+python3 "$SKILL_DIR/scripts/raindrop_mcp.py" call find_collections '{"limit":50}'
+python3 "$SKILL_DIR/scripts/raindrop_mcp.py" call find_tags '{"limit":50}'
+python3 "$SKILL_DIR/scripts/raindrop_mcp.py" call find_highlights '{"limit":20}'
+```
+
+Find cleanup candidates:
+
+```bash
+python3 "$SKILL_DIR/scripts/raindrop_mcp.py" call find_misplaced_bookmarks '{"limit":20}'
+python3 "$SKILL_DIR/scripts/raindrop_mcp.py" call find_mistagged_bookmarks '{"limit":20}'
+```
+
+## Response Style
+
+- Summarize only the useful fields; do not dump raw bookmark payloads unless requested.
+- Include direct bookmark URLs when they help the user act.
+- For organization audits, group findings into small actionable batches rather than trying to clean the whole library at once.

--- a/.config/agent-skills/skills/raindrop-mcp/agents/openai.yaml
+++ b/.config/agent-skills/skills/raindrop-mcp/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Raindrop MCP"
+  short_description: "Work with Raindrop.io bookmarks through the official MCP endpoint."
+  default_prompt: "Use Raindrop MCP to verify access, search bookmarks, inspect tags/collections/highlights, or fetch bookmark content."

--- a/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
+++ b/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
@@ -99,7 +99,7 @@ class RaindropMcpClient:
             if self.session_id:
                 try:
                     response = self.read_stream_response(request_id)
-                except SessionExpired:
+                except SessionExpired as stream_exc:
                     if retry_session_expired and method != "initialize":
                         self.reset_session()
                         self.initialize(retry_session_expired=False)
@@ -109,7 +109,10 @@ class RaindropMcpClient:
                             expect_response=expect_response,
                             retry_session_expired=False,
                         )
-                    raise exc
+                    raise SystemExit(
+                        f"MCP session expired while reading fallback stream for {method}; "
+                        "the request could not be retried."
+                    ) from stream_exc
                 data = select_response(decode_response(response), request_id)
             else:
                 raise exc

--- a/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
+++ b/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
@@ -6,6 +6,7 @@ import urllib.error
 import urllib.request
 
 ENDPOINT = "https://api.raindrop.io/rest/v2/ai/mcp"
+PROTOCOL_VERSION = "2024-11-05"
 
 
 class RaindropMcpClient:
@@ -19,19 +20,23 @@ class RaindropMcpClient:
         self.next_id = 1
         self.session_id = None
 
-    def request(self, method, params=None):
+    def request(self, method, params=None, expect_response=True):
         payload = {
             "jsonrpc": "2.0",
-            "id": self.next_id,
             "method": method,
             "params": params or {},
         }
-        self.next_id += 1
+        request_id = None
+        if expect_response:
+            request_id = self.next_id
+            payload["id"] = request_id
+            self.next_id += 1
 
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Accept": "application/json, text/event-stream",
             "Content-Type": "application/json",
+            "MCP-Protocol-Version": PROTOCOL_VERSION,
         }
         if self.session_id:
             headers["Mcp-Session-Id"] = self.session_id
@@ -55,21 +60,29 @@ class RaindropMcpClient:
         except urllib.error.URLError as exc:
             raise SystemExit(f"Request failed: {exc.reason}") from exc
 
-        data = decode_response(raw)
+        if not expect_response:
+            return None
+
+        data = select_response(decode_response(raw), request_id)
         if "error" in data:
             raise SystemExit(json.dumps(data["error"], indent=2, sort_keys=True))
         result = data.get("result", data)
-        return unwrap_content_text(result)
+        result = unwrap_content_text(result)
+        if isinstance(result, dict) and result.get("isError") is True:
+            raise SystemExit(json.dumps(result, indent=2, sort_keys=True))
+        return result
 
     def initialize(self):
-        return self.request(
+        result = self.request(
             "initialize",
             {
-                "protocolVersion": "2024-11-05",
+                "protocolVersion": PROTOCOL_VERSION,
                 "capabilities": {},
                 "clientInfo": {"name": "codex-raindrop-helper", "version": "1"},
             },
         )
+        self.request("notifications/initialized", expect_response=False)
+        return result
 
 
 def decode_response(raw):
@@ -81,7 +94,7 @@ def decode_response(raw):
     data_lines = []
     for line in raw.splitlines():
         if line.startswith("data:"):
-            data = line.removeprefix("data:").strip()
+            data = line[5:].strip()
             if data and data != "[DONE]":
                 data_lines.append(data)
 
@@ -92,6 +105,20 @@ def decode_response(raw):
             continue
 
     raise SystemExit("Response was not valid JSON or JSON-bearing server-sent events.")
+
+
+def select_response(data, request_id):
+    if isinstance(data, dict):
+        return data
+    if not isinstance(data, list):
+        raise SystemExit("Response was not a JSON-RPC object or batch.")
+    for item in data:
+        if isinstance(item, dict) and item.get("id") == request_id:
+            return item
+    for item in data:
+        if isinstance(item, dict) and ("result" in item or "error" in item):
+            return item
+    raise SystemExit("Batched response did not contain a usable JSON-RPC response.")
 
 
 def unwrap_content_text(result):

--- a/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
+++ b/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
@@ -9,6 +9,10 @@ ENDPOINT = "https://api.raindrop.io/rest/v2/ai/mcp"
 PROTOCOL_VERSION = "2025-11-25"
 
 
+class SessionExpired(Exception):
+    pass
+
+
 class RaindropMcpClient:
     def __init__(self):
         token = os.environ.get("RAINDROP_ACCESS_TOKEN")
@@ -20,6 +24,7 @@ class RaindropMcpClient:
         self.token = token.strip()
         self.next_id = 1
         self.session_id = None
+        self.last_event_id = None
         self.protocol_version = PROTOCOL_VERSION
 
     def request(self, method, params=None, expect_response=True, retry_session_expired=True):
@@ -52,10 +57,10 @@ class RaindropMcpClient:
 
         try:
             with urllib.request.urlopen(req, timeout=30) as resp:
-                raw = resp.read().decode("utf-8", errors="replace")
                 session_id = resp.headers.get("Mcp-Session-Id")
                 if session_id:
                     self.session_id = session_id
+                response = self.read_response(resp, request_id)
         except urllib.error.HTTPError as exc:
             if (
                 exc.code == 404
@@ -79,9 +84,27 @@ class RaindropMcpClient:
         if not expect_response:
             return None
 
-        if not raw.strip() and self.session_id:
-            raw = self.read_stream_response()
-        data = select_response(decode_response(raw), request_id)
+        try:
+            data = select_response(decode_response(response), request_id)
+        except SystemExit as exc:
+            if self.session_id:
+                try:
+                    response = self.read_stream_response(request_id)
+                except SessionExpired:
+                    if retry_session_expired and method not in {"initialize", "notifications/initialized"}:
+                        self.session_id = None
+                        self.last_event_id = None
+                        self.initialize()
+                        return self.request(
+                            method,
+                            params,
+                            expect_response=expect_response,
+                            retry_session_expired=False,
+                        )
+                    raise exc
+                data = select_response(decode_response(response), request_id)
+            else:
+                raise exc
         if "error" in data:
             raise SystemExit(json.dumps(data["error"], indent=2, sort_keys=True))
         result = data.get("result", data)
@@ -104,18 +127,28 @@ class RaindropMcpClient:
         self.request("notifications/initialized", expect_response=False)
         return result
 
-    def read_stream_response(self):
+    def read_response(self, resp, request_id):
+        content_type = resp.headers.get("Content-Type", "")
+        if "text/event-stream" in content_type:
+            return read_sse_events(resp, request_id, self)
+        return resp.read().decode("utf-8", errors="replace")
+
+    def read_stream_response(self, request_id):
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Accept": "text/event-stream, application/json",
             "MCP-Protocol-Version": self.protocol_version,
             "Mcp-Session-Id": self.session_id,
         }
+        if self.last_event_id:
+            headers["Last-Event-ID"] = self.last_event_id
         req = urllib.request.Request(ENDPOINT, headers=headers, method="GET")
         try:
             with urllib.request.urlopen(req, timeout=30) as resp:
-                return resp.read().decode("utf-8", errors="replace")
+                return self.read_response(resp, request_id)
         except urllib.error.HTTPError as exc:
+            if exc.code == 404:
+                raise SessionExpired from exc
             detail = exc.read().decode("utf-8", errors="replace")
             raise SystemExit(f"HTTP {exc.code} while reading MCP stream: {detail}") from exc
         except urllib.error.URLError as exc:
@@ -123,6 +156,8 @@ class RaindropMcpClient:
 
 
 def decode_response(raw):
+    if isinstance(raw, (dict, list)):
+        return raw
     try:
         return json.loads(raw)
     except json.JSONDecodeError:
@@ -130,15 +165,20 @@ def decode_response(raw):
 
     event_payloads = []
     event_data_lines = []
+    event_id = None
     for line in raw.splitlines():
         if line.startswith("data:"):
-            data = line[5:].strip()
-            if data and data != "[DONE]":
+            data = strip_sse_field_value(line[5:])
+            if data != "[DONE]":
                 event_data_lines.append(data)
-        elif not line and event_data_lines:
-            event_payloads.append("\n".join(event_data_lines))
+        elif line.startswith("id:"):
+            event_id = strip_sse_field_value(line[3:])
+        elif not line:
+            if event_id is not None or event_data_lines:
+                event_payloads.append("\n".join(event_data_lines))
             event_data_lines = []
-    if event_data_lines:
+            event_id = None
+    if event_id is not None or event_data_lines:
         event_payloads.append("\n".join(event_data_lines))
 
     parsed_payloads = []
@@ -153,6 +193,58 @@ def decode_response(raw):
         return parsed_payloads
 
     raise SystemExit("Response was not valid JSON or JSON-bearing server-sent events.")
+
+
+def strip_sse_field_value(value):
+    if value.startswith(" "):
+        return value[1:]
+    return value
+
+
+def read_sse_events(resp, request_id, client):
+    parsed_payloads = []
+    event_data_lines = []
+    event_id = None
+    for raw_line in resp:
+        line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+        if line.startswith("id:"):
+            event_id = strip_sse_field_value(line[3:])
+            if event_id:
+                client.last_event_id = event_id
+        elif line.startswith("data:"):
+            data = strip_sse_field_value(line[5:])
+            if data != "[DONE]":
+                event_data_lines.append(data)
+        elif line == "":
+            parsed = parse_sse_event(event_data_lines)
+            if parsed is not None:
+                parsed_payloads.append(parsed)
+                try:
+                    return select_response(parsed, request_id)
+                except SystemExit:
+                    pass
+            event_data_lines = []
+            event_id = None
+    parsed = parse_sse_event(event_data_lines)
+    if parsed is not None:
+        parsed_payloads.append(parsed)
+        try:
+            return select_response(parsed, request_id)
+        except SystemExit:
+            pass
+    return parsed_payloads
+
+
+def parse_sse_event(event_data_lines):
+    if not event_data_lines:
+        return None
+    payload = "\n".join(event_data_lines)
+    if not payload:
+        return None
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
+        return None
 
 
 def iter_response_objects(data):

--- a/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
+++ b/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import os
+import time
 import urllib.error
 import urllib.request
 
@@ -25,7 +26,13 @@ class RaindropMcpClient:
         self.next_id = 1
         self.session_id = None
         self.last_event_id = None
+        self.retry_delay_ms = None
         self.protocol_version = PROTOCOL_VERSION
+
+    def reset_session(self):
+        self.session_id = None
+        self.last_event_id = None
+        self.retry_delay_ms = None
 
     def request(self, method, params=None, expect_response=True, retry_session_expired=True):
         payload = {
@@ -66,10 +73,12 @@ class RaindropMcpClient:
                 exc.code == 404
                 and self.session_id
                 and retry_session_expired
-                and method not in {"initialize", "notifications/initialized"}
+                and method != "initialize"
             ):
-                self.session_id = None
-                self.initialize()
+                self.reset_session()
+                self.initialize(retry_session_expired=False)
+                if method == "notifications/initialized":
+                    return None
                 return self.request(
                     method,
                     params,
@@ -91,10 +100,9 @@ class RaindropMcpClient:
                 try:
                     response = self.read_stream_response(request_id)
                 except SessionExpired:
-                    if retry_session_expired and method not in {"initialize", "notifications/initialized"}:
-                        self.session_id = None
-                        self.last_event_id = None
-                        self.initialize()
+                    if retry_session_expired and method != "initialize":
+                        self.reset_session()
+                        self.initialize(retry_session_expired=False)
                         return self.request(
                             method,
                             params,
@@ -113,7 +121,7 @@ class RaindropMcpClient:
             raise SystemExit(json.dumps(result, indent=2, sort_keys=True))
         return result
 
-    def initialize(self):
+    def initialize(self, retry_session_expired=True):
         result = self.request(
             "initialize",
             {
@@ -121,10 +129,15 @@ class RaindropMcpClient:
                 "capabilities": {},
                 "clientInfo": {"name": "codex-raindrop-helper", "version": "1"},
             },
+            retry_session_expired=retry_session_expired,
         )
         if isinstance(result, dict) and isinstance(result.get("protocolVersion"), str):
             self.protocol_version = result["protocolVersion"]
-        self.request("notifications/initialized", expect_response=False)
+        self.request(
+            "notifications/initialized",
+            expect_response=False,
+            retry_session_expired=retry_session_expired,
+        )
         return result
 
     def read_response(self, resp, request_id):
@@ -134,6 +147,8 @@ class RaindropMcpClient:
         return resp.read().decode("utf-8", errors="replace")
 
     def read_stream_response(self, request_id):
+        if self.retry_delay_ms is not None:
+            time.sleep(self.retry_delay_ms / 1000)
         headers = {
             "Authorization": f"Bearer {self.token}",
             "Accept": "text/event-stream, application/json",
@@ -215,6 +230,10 @@ def read_sse_events(resp, request_id, client):
             data = strip_sse_field_value(line[5:])
             if data != "[DONE]":
                 event_data_lines.append(data)
+        elif line.startswith("retry:"):
+            retry = strip_sse_field_value(line[6:])
+            if retry.isdigit():
+                client.retry_delay_ms = int(retry)
         elif line == "":
             parsed = parse_sse_event(event_data_lines)
             if parsed is not None:

--- a/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
+++ b/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
@@ -2,51 +2,96 @@
 import argparse
 import json
 import os
-import sys
 import urllib.error
 import urllib.request
 
 ENDPOINT = "https://api.raindrop.io/rest/v2/ai/mcp"
 
 
-def request(method, params=None):
-    token = os.environ.get("RAINDROP_ACCESS_TOKEN")
-    if not token:
-        raise SystemExit(
-            "RAINDROP_ACCESS_TOKEN is not set. Source the host's local shell exports "
-            "or set RAINDROP_ACCESS_TOKEN in the environment."
-        )
+class RaindropMcpClient:
+    def __init__(self):
+        self.token = os.environ.get("RAINDROP_ACCESS_TOKEN")
+        if not self.token:
+            raise SystemExit(
+                "RAINDROP_ACCESS_TOKEN is not set. Source the host's local shell exports "
+                "or set RAINDROP_ACCESS_TOKEN in the environment."
+            )
+        self.next_id = 1
+        self.session_id = None
 
-    payload = {
-        "jsonrpc": "2.0",
-        "id": 1,
-        "method": method,
-        "params": params or {},
-    }
-    body = json.dumps(payload).encode("utf-8")
-    req = urllib.request.Request(
-        ENDPOINT,
-        data=body,
-        headers={
-            "Authorization": f"Bearer {token}",
+    def request(self, method, params=None):
+        payload = {
+            "jsonrpc": "2.0",
+            "id": self.next_id,
+            "method": method,
+            "params": params or {},
+        }
+        self.next_id += 1
+
+        headers = {
+            "Authorization": f"Bearer {self.token}",
             "Accept": "application/json, text/event-stream",
             "Content-Type": "application/json",
-        },
-        method="POST",
-    )
+        }
+        if self.session_id:
+            headers["Mcp-Session-Id"] = self.session_id
 
+        req = urllib.request.Request(
+            ENDPOINT,
+            data=json.dumps(payload).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+                session_id = resp.headers.get("Mcp-Session-Id")
+                if session_id:
+                    self.session_id = session_id
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise SystemExit(f"HTTP {exc.code}: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise SystemExit(f"Request failed: {exc.reason}") from exc
+
+        data = decode_response(raw)
+        if "error" in data:
+            raise SystemExit(json.dumps(data["error"], indent=2, sort_keys=True))
+        result = data.get("result", data)
+        return unwrap_content_text(result)
+
+    def initialize(self):
+        return self.request(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "codex-raindrop-helper", "version": "1"},
+            },
+        )
+
+
+def decode_response(raw):
     try:
-        with urllib.request.urlopen(req, timeout=30) as resp:
-            raw = resp.read().decode("utf-8")
-    except urllib.error.HTTPError as exc:
-        detail = exc.read().decode("utf-8", errors="replace")
-        raise SystemExit(f"HTTP {exc.code}: {detail}") from exc
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        pass
 
-    data = json.loads(raw)
-    if "error" in data:
-        raise SystemExit(json.dumps(data["error"], indent=2, sort_keys=True))
-    result = data.get("result", data)
-    return unwrap_content_text(result)
+    data_lines = []
+    for line in raw.splitlines():
+        if line.startswith("data:"):
+            data = line.removeprefix("data:").strip()
+            if data and data != "[DONE]":
+                data_lines.append(data)
+
+    for data in reversed(data_lines):
+        try:
+            return json.loads(data)
+        except json.JSONDecodeError:
+            continue
+
+    raise SystemExit("Response was not valid JSON or JSON-bearing server-sent events.")
 
 
 def unwrap_content_text(result):
@@ -63,18 +108,26 @@ def unwrap_content_text(result):
         return result
 
     try:
-        return json.loads(text)
+        parsed = json.loads(text)
     except json.JSONDecodeError:
         return result
+    if set(result.keys()) == {"content"}:
+        return parsed
+    unwrapped = dict(result)
+    unwrapped["content"] = parsed
+    return unwrapped
 
 
 def parse_json_arg(raw):
     if not raw:
         return {}
     try:
-        return json.loads(raw)
+        parsed = json.loads(raw)
     except json.JSONDecodeError as exc:
         raise SystemExit(f"Invalid JSON arguments: {exc}") from exc
+    if not isinstance(parsed, dict):
+        raise SystemExit("Tool arguments must be a JSON object.")
+    return parsed
 
 
 def main():
@@ -87,19 +140,15 @@ def main():
     call.add_argument("arguments", nargs="?", help="JSON object of tool arguments.")
     args = parser.parse_args()
 
+    client = RaindropMcpClient()
     if args.cmd == "initialize":
-        result = request(
-            "initialize",
-            {
-                "protocolVersion": "2024-11-05",
-                "capabilities": {},
-                "clientInfo": {"name": "codex-raindrop-helper", "version": "1"},
-            },
-        )
+        result = client.initialize()
     elif args.cmd == "tools":
-        result = request("tools/list")
+        client.initialize()
+        result = client.request("tools/list")
     else:
-        result = request(
+        client.initialize()
+        result = client.request(
             "tools/call",
             {"name": args.tool, "arguments": parse_json_arg(args.arguments)},
         )

--- a/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
+++ b/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
@@ -138,16 +138,15 @@ def decode_response(raw):
 
 def select_response(data, request_id):
     if isinstance(data, dict):
+        if data.get("id") != request_id:
+            raise SystemExit("Response did not match the active JSON-RPC request id.")
         return data
     if not isinstance(data, list):
         raise SystemExit("Response was not a JSON-RPC object or batch.")
     for item in data:
         if isinstance(item, dict) and item.get("id") == request_id:
             return item
-    for item in data:
-        if isinstance(item, dict) and ("result" in item or "error" in item):
-            return item
-    raise SystemExit("Batched response did not contain a usable JSON-RPC response.")
+    raise SystemExit("Batched response did not contain the active JSON-RPC request id.")
 
 
 def unwrap_content_text(result):

--- a/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
+++ b/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+ENDPOINT = "https://api.raindrop.io/rest/v2/ai/mcp"
+
+
+def request(method, params=None):
+    token = os.environ.get("RAINDROP_ACCESS_TOKEN")
+    if not token:
+        raise SystemExit(
+            "RAINDROP_ACCESS_TOKEN is not set. Source the host's local shell exports "
+            "or set RAINDROP_ACCESS_TOKEN in the environment."
+        )
+
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": method,
+        "params": params or {},
+    }
+    body = json.dumps(payload).encode("utf-8")
+    req = urllib.request.Request(
+        ENDPOINT,
+        data=body,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json, text/event-stream",
+            "Content-Type": "application/json",
+        },
+        method="POST",
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            raw = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as exc:
+        detail = exc.read().decode("utf-8", errors="replace")
+        raise SystemExit(f"HTTP {exc.code}: {detail}") from exc
+
+    data = json.loads(raw)
+    if "error" in data:
+        raise SystemExit(json.dumps(data["error"], indent=2, sort_keys=True))
+    result = data.get("result", data)
+    return unwrap_content_text(result)
+
+
+def unwrap_content_text(result):
+    content = result.get("content") if isinstance(result, dict) else None
+    if not isinstance(content, list) or len(content) != 1:
+        return result
+
+    item = content[0]
+    if not isinstance(item, dict) or item.get("type") != "text":
+        return result
+
+    text = item.get("text")
+    if not isinstance(text, str):
+        return result
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        return result
+
+
+def parse_json_arg(raw):
+    if not raw:
+        return {}
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise SystemExit(f"Invalid JSON arguments: {exc}") from exc
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Call the official Raindrop.io MCP endpoint.")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("initialize", help="Run an MCP initialize probe.")
+    sub.add_parser("tools", help="List available MCP tools.")
+    call = sub.add_parser("call", help="Call a named MCP tool.")
+    call.add_argument("tool")
+    call.add_argument("arguments", nargs="?", help="JSON object of tool arguments.")
+    args = parser.parse_args()
+
+    if args.cmd == "initialize":
+        result = request(
+            "initialize",
+            {
+                "protocolVersion": "2024-11-05",
+                "capabilities": {},
+                "clientInfo": {"name": "codex-raindrop-helper", "version": "1"},
+            },
+        )
+    elif args.cmd == "tools":
+        result = request("tools/list")
+    else:
+        result = request(
+            "tools/call",
+            {"name": args.tool, "arguments": parse_json_arg(args.arguments)},
+        )
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
+++ b/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
@@ -22,7 +22,7 @@ class RaindropMcpClient:
         self.session_id = None
         self.protocol_version = PROTOCOL_VERSION
 
-    def request(self, method, params=None, expect_response=True):
+    def request(self, method, params=None, expect_response=True, retry_session_expired=True):
         payload = {
             "jsonrpc": "2.0",
             "method": method,
@@ -57,6 +57,20 @@ class RaindropMcpClient:
                 if session_id:
                     self.session_id = session_id
         except urllib.error.HTTPError as exc:
+            if (
+                exc.code == 404
+                and self.session_id
+                and retry_session_expired
+                and method not in {"initialize", "notifications/initialized"}
+            ):
+                self.session_id = None
+                self.initialize()
+                return self.request(
+                    method,
+                    params,
+                    expect_response=expect_response,
+                    retry_session_expired=False,
+                )
             detail = exc.read().decode("utf-8", errors="replace")
             raise SystemExit(f"HTTP {exc.code}: {detail}") from exc
         except urllib.error.URLError as exc:
@@ -108,11 +122,16 @@ def decode_response(raw):
     if event_data_lines:
         event_payloads.append("\n".join(event_data_lines))
 
-    for data in reversed(event_payloads):
+    parsed_payloads = []
+    for data in event_payloads:
         try:
-            return json.loads(data)
+            parsed_payloads.append(json.loads(data))
         except json.JSONDecodeError:
             continue
+    if len(parsed_payloads) == 1:
+        return parsed_payloads[0]
+    if parsed_payloads:
+        return parsed_payloads
 
     raise SystemExit("Response was not valid JSON or JSON-bearing server-sent events.")
 

--- a/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
+++ b/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
@@ -6,19 +6,21 @@ import urllib.error
 import urllib.request
 
 ENDPOINT = "https://api.raindrop.io/rest/v2/ai/mcp"
-PROTOCOL_VERSION = "2024-11-05"
+PROTOCOL_VERSION = "2025-11-25"
 
 
 class RaindropMcpClient:
     def __init__(self):
-        self.token = os.environ.get("RAINDROP_ACCESS_TOKEN")
-        if not self.token:
+        token = os.environ.get("RAINDROP_ACCESS_TOKEN")
+        if not token or not token.strip():
             raise SystemExit(
                 "RAINDROP_ACCESS_TOKEN is not set. Source the host's local shell exports "
                 "or set RAINDROP_ACCESS_TOKEN in the environment."
             )
+        self.token = token.strip()
         self.next_id = 1
         self.session_id = None
+        self.protocol_version = PROTOCOL_VERSION
 
     def request(self, method, params=None, expect_response=True):
         payload = {
@@ -36,7 +38,7 @@ class RaindropMcpClient:
             "Authorization": f"Bearer {self.token}",
             "Accept": "application/json, text/event-stream",
             "Content-Type": "application/json",
-            "MCP-Protocol-Version": PROTOCOL_VERSION,
+            "MCP-Protocol-Version": self.protocol_version,
         }
         if self.session_id:
             headers["Mcp-Session-Id"] = self.session_id
@@ -81,6 +83,8 @@ class RaindropMcpClient:
                 "clientInfo": {"name": "codex-raindrop-helper", "version": "1"},
             },
         )
+        if isinstance(result, dict) and isinstance(result.get("protocolVersion"), str):
+            self.protocol_version = result["protocolVersion"]
         self.request("notifications/initialized", expect_response=False)
         return result
 
@@ -91,14 +95,20 @@ def decode_response(raw):
     except json.JSONDecodeError:
         pass
 
-    data_lines = []
+    event_payloads = []
+    event_data_lines = []
     for line in raw.splitlines():
         if line.startswith("data:"):
             data = line[5:].strip()
             if data and data != "[DONE]":
-                data_lines.append(data)
+                event_data_lines.append(data)
+        elif not line and event_data_lines:
+            event_payloads.append("\n".join(event_data_lines))
+            event_data_lines = []
+    if event_data_lines:
+        event_payloads.append("\n".join(event_data_lines))
 
-    for data in reversed(data_lines):
+    for data in reversed(event_payloads):
         try:
             return json.loads(data)
         except json.JSONDecodeError:

--- a/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
+++ b/.config/agent-skills/skills/raindrop-mcp/scripts/raindrop_mcp.py
@@ -79,6 +79,8 @@ class RaindropMcpClient:
         if not expect_response:
             return None
 
+        if not raw.strip() and self.session_id:
+            raw = self.read_stream_response()
         data = select_response(decode_response(raw), request_id)
         if "error" in data:
             raise SystemExit(json.dumps(data["error"], indent=2, sort_keys=True))
@@ -101,6 +103,23 @@ class RaindropMcpClient:
             self.protocol_version = result["protocolVersion"]
         self.request("notifications/initialized", expect_response=False)
         return result
+
+    def read_stream_response(self):
+        headers = {
+            "Authorization": f"Bearer {self.token}",
+            "Accept": "text/event-stream, application/json",
+            "MCP-Protocol-Version": self.protocol_version,
+            "Mcp-Session-Id": self.session_id,
+        }
+        req = urllib.request.Request(ENDPOINT, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=30) as resp:
+                return resp.read().decode("utf-8", errors="replace")
+        except urllib.error.HTTPError as exc:
+            detail = exc.read().decode("utf-8", errors="replace")
+            raise SystemExit(f"HTTP {exc.code} while reading MCP stream: {detail}") from exc
+        except urllib.error.URLError as exc:
+            raise SystemExit(f"MCP stream read failed: {exc.reason}") from exc
 
 
 def decode_response(raw):
@@ -136,16 +155,22 @@ def decode_response(raw):
     raise SystemExit("Response was not valid JSON or JSON-bearing server-sent events.")
 
 
-def select_response(data, request_id):
+def iter_response_objects(data):
     if isinstance(data, dict):
-        if data.get("id") != request_id:
-            raise SystemExit("Response did not match the active JSON-RPC request id.")
-        return data
-    if not isinstance(data, list):
+        yield data
+    elif isinstance(data, list):
+        for item in data:
+            yield from iter_response_objects(item)
+
+
+def select_response(data, request_id):
+    if not isinstance(data, (dict, list)):
         raise SystemExit("Response was not a JSON-RPC object or batch.")
-    for item in data:
-        if isinstance(item, dict) and item.get("id") == request_id:
+    for item in iter_response_objects(data):
+        if item.get("id") == request_id:
             return item
+    if isinstance(data, dict):
+        raise SystemExit("Response did not match the active JSON-RPC request id.")
     raise SystemExit("Batched response did not contain the active JSON-RPC request id.")
 
 


### PR DESCRIPTION
## Summary
- add a reusable Raindrop MCP skill for direct JSON-RPC access when native MCP tools are not exposed
- include a small helper script for listing tools and calling Raindrop MCP tools
- keep the helper path portable with SKILL_DIR guidance

## Validation
- ./scripts/check.sh
- SKILL.md frontmatter parse
- no private paths or Raindrop token values in the skill folder
- live fetch_current_user through the helper with local env sourced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only adds a new optional skill (docs + a standalone Python CLI) without modifying existing runtime code paths; the main risk is operational misconfiguration around `RAINDROP_ACCESS_TOKEN` when users invoke the helper.
> 
> **Overview**
> Adds a new `raindrop-mcp` skill that documents how to access Raindrop.io via the official remote MCP endpoint when `mcp__raindrop__...` tools aren’t available, with guidance to verify access via `fetch_current_user` and to avoid mutations unless explicitly requested.
> 
> Introduces a portable Python helper (`scripts/raindrop_mcp.py`) to `initialize`, list `tools`, and `tools/call` the endpoint over JSON-RPC, including basic MCP session tracking and SSE/stream fallback handling, plus an `agents/openai.yaml` entry for UI metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4cce00dd2f7a14d96ba960eafdd95a9be3dd3d67. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Raindrop.io MCP integration: search, inspect, and manage bookmarks, collections, tags, highlights, and metadata via a CLI (initialize session, list tools, invoke tools with JSON arguments; formatted JSON output and session retry handling).

* **Documentation**
  * User guide: authentication/verification steps, recommended read-only commands, response-formatting rules, and audit/reporting suggestions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/20?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->