### PR TITLE
Add Tripsy and Trakt CLI skills

### DIFF
--- a/.config/agent-skills/skills/trakt-cli/SKILL.md
+++ b/.config/agent-skills/skills/trakt-cli/SKILL.md
@@ -8,7 +8,7 @@ description: Work with Trakt.tv through the local trakt-cli. Use when Codex need
 ## Core Rules
 
 - Use the local CLI directly. Prefer `trakt-cli` from `PATH`.
-- These examples target the `trakt-cli` command surface that exposes `configure`, `auth`, `me`, `movies`, `shows`, `recommendations`, and `sync` in `trakt-cli --help`. If a host has a different Trakt CLI package with only commands such as `search`, `history`, `watchlist`, `calendar`, and `progress`, treat it as an unsupported variant for this skill and inspect its help before proceeding.
+- These examples target the `trakt-cli` command surface that exposes `configure`, `auth`, `me`, `movies`, `shows`, `recommendations`, `calendars`, and `sync` in `trakt-cli --help`. If a host has a different Trakt CLI package with commands such as `search`, `history`, `watchlist`, `calendar`, and `progress`, treat it as a different supported command surface: inspect its help and translate the workflow instead of applying these examples verbatim.
 - Prove access with a live read before claiming Trakt works:
 
 ```bash
@@ -61,8 +61,8 @@ Browse:
 ```bash
 trakt-cli movies trending --json
 trakt-cli shows trending --json
-trakt-cli calendars shows --json
-trakt-cli calendars premieres --json
+trakt-cli calendars my-shows --json
+trakt-cli calendars all-new-shows --json
 ```
 
 Personal data:

--- a/.config/agent-skills/skills/trakt-cli/SKILL.md
+++ b/.config/agent-skills/skills/trakt-cli/SKILL.md
@@ -8,6 +8,7 @@ description: Work with Trakt.tv through the local trakt-cli. Use when Codex need
 ## Core Rules
 
 - Use the local CLI directly. Prefer `trakt-cli` from `PATH`.
+- These examples target the `trakt-cli` command surface that exposes `configure`, `auth`, `me`, `movies`, `shows`, `recommendations`, and `sync` in `trakt-cli --help`. If a host has a different Trakt CLI package with only commands such as `search`, `history`, `watchlist`, `calendar`, and `progress`, treat it as an unsupported variant for this skill and inspect its help before proceeding.
 - Prove access with a live read before claiming Trakt works:
 
 ```bash
@@ -34,6 +35,8 @@ Use a descriptive app name such as `<host> Codex` or `Local Agent CLI`. For a lo
 ```text
 urn:ietf:wg:oauth:2.0:oob
 ```
+
+This is the out-of-band PIN-style OAuth flow used by the CLI; after `trakt-cli auth`, follow the printed browser/PIN instructions.
 
 Then configure and authenticate:
 

--- a/.config/agent-skills/skills/trakt-cli/SKILL.md
+++ b/.config/agent-skills/skills/trakt-cli/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: trakt-cli
+description: Work with Trakt.tv through the local trakt-cli. Use when Codex needs to verify Trakt access, inspect movies, shows, calendars, recommendations, watchlists, ratings, history, playback, or carefully update authenticated Trakt account state from the command line.
+---
+
+# Trakt CLI
+
+## Core Rules
+
+- Use the local CLI directly. Prefer `trakt-cli` from `PATH`.
+- Prove access with a live read before claiming Trakt works:
+
+```bash
+trakt-cli --help
+trakt-cli me --json
+trakt-cli sync watchlist --limit 3 --json
+```
+
+- Personalized commands require `trakt-cli configure` and `trakt-cli auth`.
+- Prefer `--json` for agent work.
+- Do not add, remove, rate, check in, scrobble, or mutate Trakt items unless the user explicitly asks for that exact change.
+- Resolve titles to a specific Trakt item before any write.
+
+## Setup
+
+Create a Trakt API app at:
+
+```text
+https://trakt.tv/oauth/applications/new
+```
+
+Use a descriptive app name such as `<host> Codex` or `Local Agent CLI`. For a local/headless CLI flow, use a non-web redirect URI such as:
+
+```text
+urn:ietf:wg:oauth:2.0:oob
+```
+
+Then configure and authenticate:
+
+```bash
+trakt-cli configure --client-id "$TRAKT_CLIENT_ID" --client-secret "$TRAKT_CLIENT_SECRET"
+trakt-cli auth
+```
+
+## Common Reads
+
+Search and inspect:
+
+```bash
+trakt-cli search text movie "The Matrix" --json
+trakt-cli search text show "Severance" --json
+trakt-cli movies get "the-matrix-1999" --extended full --json
+trakt-cli shows get "severance" --extended full --json
+```
+
+Browse:
+
+```bash
+trakt-cli movies trending --json
+trakt-cli shows trending --json
+trakt-cli calendars shows --json
+trakt-cli calendars premieres --json
+```
+
+Personal data:
+
+```bash
+trakt-cli sync watchlist --json
+trakt-cli recommendations movies --json
+trakt-cli sync history --type episodes --json
+```
+
+Note: on some `trakt-cli` releases, `sync playback` and `sync last-activities` return `HTTP 405 Method Not Allowed`; avoid using them as health checks until the CLI route is fixed upstream.
+
+## Mutation Guardrails
+
+- Search first when the user gives a title, then pick the matching type/year before writing.
+- Use the smallest JSON payload that matches the target item type.
+- For destructive operations such as remove, reset, clear, unlike, unfollow, or reorder, state exactly what will change before running the command.
+
+Example watchlist write after resolving a movie ID:
+
+```bash
+trakt-cli sync add-watchlist --items '{"movies":[{"ids":{"trakt":603}}]}' --json
+```
+
+## Response Style
+
+- Mention the resolved title, media type, and year when available.
+- Summarize the result instead of dumping raw JSON unless requested.
+- For writes, state exactly what changed.

--- a/.config/agent-skills/skills/trakt-cli/agents/openai.yaml
+++ b/.config/agent-skills/skills/trakt-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Trakt CLI"
+  short_description: "Work with Trakt.tv data from the local CLI."
+  default_prompt: "Use Trakt CLI to inspect movies, shows, watchlists, calendars, recommendations, ratings, history, or playback."

--- a/.config/agent-skills/skills/trakt-cli/agents/openai.yaml
+++ b/.config/agent-skills/skills/trakt-cli/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Trakt CLI"
   short_description: "Work with Trakt.tv data from the local CLI."
-  default_prompt: "Use Trakt CLI to inspect movies, shows, watchlists, calendars, recommendations, ratings, history, or playback."
+  default_prompt: "Use the supported Trakt CLI command surface to inspect movies, shows, watchlists, calendars, recommendations, ratings, history, or playback."

--- a/.config/agent-skills/skills/tripsy-cli/SKILL.md
+++ b/.config/agent-skills/skills/tripsy-cli/SKILL.md
@@ -45,7 +45,7 @@ Trip details:
 "$TRIPSY_BIN" hostings list --trip <trip-id> --json
 "$TRIPSY_BIN" transportations list --trip <trip-id> --json
 "$TRIPSY_BIN" expenses list --trip <trip-id> --json
-"$TRIPSY_BIN" collaborators --trip <trip-id> --json
+"$TRIPSY_BIN" collaborators list --trip <trip-id> --json
 ```
 
 Agent command catalog:

--- a/.config/agent-skills/skills/tripsy-cli/SKILL.md
+++ b/.config/agent-skills/skills/tripsy-cli/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: tripsy-cli
+description: Work with Tripsy travel data through the local Tripsy CLI. Use when Codex needs to verify Tripsy access, inspect trips, list or update trip activities, lodging, transport, expenses, collaborators, inbox items, documents, or plan/write Tripsy itineraries from the command line instead of relying on the remote Tripsy MCP.
+---
+
+# Tripsy CLI
+
+## Core Rules
+
+- Use the local CLI directly. Prefer `$HOME/.local/bin/tripsy`; if unavailable, check `command -v tripsy`.
+- Prove access with a live read before claiming Tripsy works:
+
+```bash
+"$HOME/.local/bin/tripsy" doctor
+"$HOME/.local/bin/tripsy" auth status --json
+```
+
+- Treat the remote Tripsy MCP as optional. Prefer the CLI when the remote MCP is configured but does not expose tools or has session/auth instability.
+- Prefer `--json` for agent work. Use `--quiet` when you need raw JSON data only.
+- Do not create, update, delete, upload, or attach Tripsy resources unless the user asked for that exact mutation.
+- Tripsy stores the CLI token in Keychain by default. If a scheduled/noninteractive run loses auth, check `tripsy doctor` and ask the user to re-run CLI auth rather than inventing a token.
+
+## Common Reads
+
+Current user:
+
+```bash
+"$HOME/.local/bin/tripsy" me show --json
+```
+
+Trips:
+
+```bash
+"$HOME/.local/bin/tripsy" trips list --json
+"$HOME/.local/bin/tripsy" trips following --json
+"$HOME/.local/bin/tripsy" trips show <trip-id> --json
+```
+
+Trip details:
+
+```bash
+"$HOME/.local/bin/tripsy" activities list --trip <trip-id> --json
+"$HOME/.local/bin/tripsy" hostings list --trip <trip-id> --json
+"$HOME/.local/bin/tripsy" transportations list --trip <trip-id> --json
+"$HOME/.local/bin/tripsy" expenses list --trip <trip-id> --json
+"$HOME/.local/bin/tripsy" collaborators --trip <trip-id> --json
+```
+
+Agent command catalog:
+
+```bash
+"$HOME/.local/bin/tripsy" commands --json
+"$HOME/.local/bin/tripsy" trips --help --agent
+```
+
+The list response is an object with `results`, `count`, `next`, and `previous`; do not assume a top-level array.
+
+## Travel Signal Use
+
+For planning or assistant-summary workflows:
+
+- Use Tripsy as bounded travel context, not as a full itinerary dump.
+- Surface travel only when it changes the day or week: active/upcoming dated trips, inbox items needing handling, lodging/flight/document gaps, or near-term planning decisions.
+- Prefer trip names, dates, destination/timezone, collaborator count, and the next concrete missing piece.
+- If Tripsy is unavailable, mention it as a data gap only when travel context materially matters.
+
+## Itinerary Mutation Guardrails
+
+When the user asks to create or refine an itinerary:
+
+- Create one Tripsy item per actual stop, reservation, meal, tour, or activity; do not combine a whole day into one activity.
+- Use exact ISO-8601 UTC datetimes for timed items plus the local `timezone`.
+- Set `latitude` and `longitude` for location-based activities, lodging, and transport when available.
+- Use `hostings` for lodging, `transportations` for point-to-point movement, and `activities` for stops/events/meals.
+- Choose the most specific supported category slug. If unsure, run command help with `--agent` before mutating.
+- Prefer a direct `images.unsplash.com/photo-...` URL for trip covers, not an Unsplash page URL.

--- a/.config/agent-skills/skills/tripsy-cli/SKILL.md
+++ b/.config/agent-skills/skills/tripsy-cli/SKILL.md
@@ -11,46 +11,48 @@ description: Work with Tripsy travel data through the local Tripsy CLI. Use when
 - Prove access with a live read before claiming Tripsy works:
 
 ```bash
-"$HOME/.local/bin/tripsy" doctor
-"$HOME/.local/bin/tripsy" auth status --json
+TRIPSY_BIN="${HOME}/.local/bin/tripsy"
+if [ ! -x "$TRIPSY_BIN" ]; then TRIPSY_BIN="$(command -v tripsy)"; fi
+"$TRIPSY_BIN" doctor
+"$TRIPSY_BIN" auth status --json
 ```
 
 - Treat the remote Tripsy MCP as optional. Prefer the CLI when the remote MCP is configured but does not expose tools or has session/auth instability.
 - Prefer `--json` for agent work. Use `--quiet` when you need raw JSON data only.
 - Do not create, update, delete, upload, or attach Tripsy resources unless the user asked for that exact mutation.
-- Tripsy stores the CLI token in Keychain by default. If a scheduled/noninteractive run loses auth, check `tripsy doctor` and ask the user to re-run CLI auth rather than inventing a token.
+- Tripsy stores the CLI token in Keychain by default. If a scheduled/noninteractive run loses auth, check `"$TRIPSY_BIN" doctor` and ask the user to re-run CLI auth rather than inventing a token.
 
 ## Common Reads
 
 Current user:
 
 ```bash
-"$HOME/.local/bin/tripsy" me show --json
+"$TRIPSY_BIN" me show --json
 ```
 
 Trips:
 
 ```bash
-"$HOME/.local/bin/tripsy" trips list --json
-"$HOME/.local/bin/tripsy" trips following --json
-"$HOME/.local/bin/tripsy" trips show <trip-id> --json
+"$TRIPSY_BIN" trips list --json
+"$TRIPSY_BIN" trips following --json
+"$TRIPSY_BIN" trips show <trip-id> --json
 ```
 
 Trip details:
 
 ```bash
-"$HOME/.local/bin/tripsy" activities list --trip <trip-id> --json
-"$HOME/.local/bin/tripsy" hostings list --trip <trip-id> --json
-"$HOME/.local/bin/tripsy" transportations list --trip <trip-id> --json
-"$HOME/.local/bin/tripsy" expenses list --trip <trip-id> --json
-"$HOME/.local/bin/tripsy" collaborators --trip <trip-id> --json
+"$TRIPSY_BIN" activities list --trip <trip-id> --json
+"$TRIPSY_BIN" hostings list --trip <trip-id> --json
+"$TRIPSY_BIN" transportations list --trip <trip-id> --json
+"$TRIPSY_BIN" expenses list --trip <trip-id> --json
+"$TRIPSY_BIN" collaborators --trip <trip-id> --json
 ```
 
 Agent command catalog:
 
 ```bash
-"$HOME/.local/bin/tripsy" commands --json
-"$HOME/.local/bin/tripsy" trips --help --agent
+"$TRIPSY_BIN" commands --json
+"$TRIPSY_BIN" trips --help --agent
 ```
 
 The list response is an object with `results`, `count`, `next`, and `previous`; do not assume a top-level array.
@@ -69,7 +71,8 @@ For planning or assistant-summary workflows:
 When the user asks to create or refine an itinerary:
 
 - Create one Tripsy item per actual stop, reservation, meal, tour, or activity; do not combine a whole day into one activity.
-- Use exact ISO-8601 UTC datetimes for timed items plus the local `timezone`.
+- Use exact UTC ISO-8601 datetimes with a trailing `Z` for timed items, such as `2026-06-01T14:00:00Z`.
+- Set the local IANA `timezone` field separately for display/localization only; do not treat it as a second authoritative time that should be converted again.
 - Set `latitude` and `longitude` for location-based activities, lodging, and transport when available.
 - Use `hostings` for lodging, `transportations` for point-to-point movement, and `activities` for stops/events/meals.
 - Choose the most specific supported category slug. If unsure, run command help with `--agent` before mutating.

--- a/.config/agent-skills/skills/tripsy-cli/agents/openai.yaml
+++ b/.config/agent-skills/skills/tripsy-cli/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Tripsy CLI"
+  short_description: "Work with Tripsy travel data from the local CLI."
+  default_prompt: "Use Tripsy CLI to inspect trips, travel plans, itinerary items, or travel inbox/document context."


### PR DESCRIPTION
## Summary
- add shared personal skills for Tripsy CLI and Trakt CLI workflows
- include OpenAI skill metadata for both skills
- document safe read-first behavior and guarded mutations

## Validation
- ./scripts/check.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new skill documentation and OpenAI metadata only; no runtime code paths or security-sensitive logic are modified.
> 
> **Overview**
> Adds two new personal agent skills, `tripsy-cli` and `trakt-cli`, to guide Codex in using the local CLIs for Tripsy travel data and Trakt.tv media data.
> 
> Each skill includes *read-first verification steps*, common JSON-friendly read commands, and explicit guardrails against unintended mutations, plus `agents/openai.yaml` metadata (display name, short description, default prompt) to expose the skills in OpenAI agent UIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76683e7130cd445084dabf075ade591fc27cc92e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Trakt CLI agent skill for exploring Trakt data (search, watchlist, sync) added.
  * Tripsy CLI agent skill for inspecting trips, itineraries, and travel data added.
  * OpenAI-facing interfaces added for both skills (display name, short description, default prompt).

* **Documentation**
  * Detailed user guides for setup, auth, common commands, output expectations, and mutation guardrails.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->