### PR TITLE
Add automation hygiene fallback

### DIFF
--- a/.config/agent-skills/skills/agent-instruction-maintenance/SKILL.md
+++ b/.config/agent-skills/skills/agent-instruction-maintenance/SKILL.md
@@ -15,7 +15,13 @@ description: "Review, update, and synchronize agent instructions and configs acr
 - Use after creating or editing instructions, or when standards change.
 
 ## Step-by-step workflow
-0) If the prompt includes automation metadata such as `Automation:`, `Automation ID:`, `Automation memory:`, or `Last run:`, load and follow `automation-run-hygiene` before scanning or editing. This prevents named maintenance-skill work from skipping automation memory normalization and inbox handoff rules.
+0) If the prompt includes automation metadata such as `Automation:`, `Automation ID:`, `Automation memory:`, or `Last run:`, load and follow `automation-run-hygiene` when that skill is available. If it is not available, apply this inline hygiene before scanning or editing:
+   - Resolve the automation ID and memory path from the prompt, then read the memory file if it exists.
+   - Use the latest successful checkpoint from memory as the scan start; otherwise use the prompt fallback window.
+   - Exclude the current automation run from historical evidence.
+   - Before finishing, append a concise run entry to the automation memory.
+   - End with the host app's required handoff or inbox directive when the environment requires one.
+This prevents named maintenance-skill work from skipping automation memory normalization and inbox handoff rules.
 1) Discover which ecosystems exist in the repo or user config.
 2) Resolve instruction file locations from the current source of truth before opening them.
 - For named skills, prefer the path supplied by the current session's skill inventory.


### PR DESCRIPTION
## Summary
- add inline automation-run hygiene fallback to agent-instruction-maintenance when the optional automation-run-hygiene skill is unavailable
- keep automation memory, checkpoint, current-run exclusion, and handoff behavior generic and portable

## Validation
- validated touched SKILL.md frontmatter fences, name, and description
- scanned touched skill text for private host names and personal paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a maintenance skill workflow; no runtime, auth, or data-path behavior.
> 
> **Overview**
> Updates **`agent-instruction-maintenance`** workflow step **0** so automation metadata in a prompt no longer *requires* the separate **`automation-run-hygiene`** skill.
> 
> When that skill is present, behavior is unchanged: still load and follow it. When it is missing, the skill now spells out an **inline fallback**—resolve automation ID/memory, read memory, derive scan start from the latest checkpoint (or prompt window), exclude the current run from evidence, append a run entry before finishing, and honor host handoff/inbox rules.
> 
> The existing rationale (avoid skipping memory normalization and handoff) is preserved; only the dependency model and portable fallback steps are new.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3092306cf4c627cf516fafe2877e49ae5a08cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced workflow instructions with detailed guidance on automation maintenance procedures, including expanded steps for handling automation metadata and memory hygiene operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/22?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->