### PR TITLE
[codex] Document public multi-host agent guidance

### DIFF
--- a/superassistant/AGENTS.md
+++ b/superassistant/AGENTS.md
@@ -35,3 +35,12 @@ Avoid duplicating repository instructions here. Keep this file focused on person
 - For cross-host assistant context, use the `shared-craft-memory` skill when available. Read it for project-adjacent personal operations, host coordination, active cross-host loops, or agent handoffs that may matter outside the current machine.
 - Keep shared Craft memory current when a material cross-host fact changes and future agents are likely to need it. Do not use it as a general activity log; live systems, project docs, and repos remain authoritative.
 - On hosts that need shared Craft memory, set `CRAFT_SHARED_MEMORY_URL` in a local ignored shell exports file such as `~/.zshrc_custom/exports-local.zsh`. Do not hard-code the private Craft link in tracked dotfiles.
+
+## Synced Multi-Host Workspace
+
+- Treat this directory as public, synced dotfiles/workspace context that may run on unlike hosts, including laptops, headless machines, Home Assistant-adjacent hosts, and CI runners.
+- Resolve the current host before host-targeted work. Prefer `AGENT_HOST_ALIAS` when set; otherwise use `hostname -s`.
+- Do not assume a tool, app, local path, browser profile, MCP server, or credential that worked on one host is available on the current host. Verify callability with a low-risk read/probe first, then state any gap.
+- Keep private links, tokens, credentials, machine-specific paths, sensitive host details, and per-host shell exports out of tracked synced files. Put those in ignored local files or the relevant source system.
+- Before adding personal operations guidance to tracked files, assume the content will be visible in the public dotfiles repository and prefer generic rules over private system names, URLs, account IDs, addresses, or internal topology.
+- Before editing nested folders, check for a more local `AGENTS.md` and whether the folder is its own Git repository. The nested repository owns its workflow and validation rules.


### PR DESCRIPTION
## Summary

- Add public synced workspace guidance for `superassistant` agent instructions.
- Require host identity resolution before host-targeted work.
- Require low-risk live probes before assuming host-specific tools, paths, credentials, or MCP servers are available.
- Keep private links, credentials, sensitive host details, account IDs, addresses, and internal topology out of tracked public dotfiles.

## Validation

- Inspected yadm status for the scoped file.
- No code tests apply; documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent instructions with no runtime, auth, or data-path impact.
> 
> **Overview**
> Adds a **Synced Multi-Host Workspace** section to `superassistant/AGENTS.md` so agents treat this tree as **public, yadm-synced** context that may run on laptops, headless hosts, HA-adjacent machines, or CI.
> 
> New rules require resolving the host via `AGENT_HOST_ALIAS` or `hostname -s` before host-specific work, **probing** tools/paths/MCP/credentials instead of assuming another machine’s setup, and keeping secrets and machine-specific exports in **ignored local** files. Guidance also tells agents to write tracked ops notes as if they will appear in the **public dotfiles repo**, and to defer to **nested `AGENTS.md` / separate Git repos** under subfolders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fbeb3f643d19e38ed4c70cacfbe2834566f0363. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated agent guidance documentation with clearer scope for workspace operations and global instructions.
  * Added new section covering multi-host workspace synchronization rules and cross-host operational guidelines.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/24?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->