### PR TITLE
Harden email draft handoff guidance against shell injection

### DIFF
--- a/.config/agent-skills/skills/email-draft-handoff/SKILL.md
+++ b/.config/agent-skills/skills/email-draft-handoff/SKILL.md
@@ -31,16 +31,20 @@ If both are used, report both:
 
 ## URL Encoding
 
-Use the helper script to avoid malformed links:
+Use the helper script to avoid malformed links.
+
+**Security rule:** never paste untrusted email fields (recipient name/address, subject, or thread text) directly into a shell command line. Load untrusted values from files first, then pass them as quoted variables:
 
 ```bash
+TO="$(cat /path/to/to.txt)"
+SUBJECT="$(cat /path/to/subject.txt)"
 python3 "$HOME/.config/agent-skills/skills/email-draft-handoff/scripts/build_mailto.py" \
-  --to "recipient@example.com" \
-  --subject "Subject here" \
+  --to "$TO" \
+  --subject "$SUBJECT" \
   --body-file /path/to/body.txt
 ```
 
-The script prints the `mailto:` URL.
+This avoids shell command substitution from attacker-controlled text. The script prints the `mailto:` URL.
 
 For short one-off drafts, it is also acceptable to use a language standard library such as Python `urllib.parse.quote`.
 
@@ -59,4 +63,3 @@ When replying to an existing support thread:
 - preserve the ticket/reference number in the subject when known
 - link to the source email separately when a `message://...` link is available
 - still use the `mailto:` link for the prefilled draft handoff
-


### PR DESCRIPTION
### Motivation
- Prevent a shell-injection risk in the email draft handoff skill by removing guidance that places untrusted recipient/subject text directly into a shell command line, which can trigger command substitution before the helper script runs.

### Description
- Updated `.config/agent-skills/skills/email-draft-handoff/SKILL.md` to add a security rule and replace the unsafe example with a pattern that reads untrusted values from files into quoted shell variables (e.g. `TO="$(cat /path/to/to.txt)"` / `SUBJECT="$(cat /path/to/subject.txt)"`) before invoking the `build_mailto.py` helper, and clarified that this prevents shell command substitution; this is a documentation-only change and does not modify scripts.

### Testing
- Verified the updated file contents with `nl -ba .config/agent-skills/skills/email-draft-handoff/SKILL.md | sed -n '32,58p'` to confirm the new guidance is present and the example was replaced, and ensured the repository state reflects the patch application successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a107a5110bc832297a30861b824f00f)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to agent skill guidance; no application code, scripts, or runtime behavior modified.
> 
> **Overview**
> Updates the **email-draft-handoff** agent skill documentation so agents do not pass untrusted recipient, subject, or body text as literal shell arguments when calling `build_mailto.py`.
> 
> The **URL Encoding** section now states a **security rule** against pasting untrusted fields on the command line, replaces the example with loading `TO` and `SUBJECT` from files into quoted variables before invoking the helper, and notes that this blocks shell command substitution. **No runtime code or scripts change**—guidance only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8a4b9b1f30cc73d8d899f20deb73cbf143df4e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->