### PR TITLE
Avoid startup-time execution of PATH-resolved docker/gh probes

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -15,6 +15,7 @@ typeset -U path PATH
 # Oh-my-zsh path
 export ZSH="$HOME/.oh-my-zsh"
 ZSH_CUSTOM="$HOME/.zshrc_custom"
+[[ -r "$ZSH_CUSTOM/docker-compose-detection.zsh" ]] && source "$ZSH_CUSTOM/docker-compose-detection.zsh"
 
 if [[ -d "$HOME/.local/bin" ]]; then
    path=("$HOME/.local/bin" $path)
@@ -64,52 +65,10 @@ plugins=(
    zsh-syntax-highlighting
 )
 
-# Print candidate Compose v2 plugin executables without invoking Docker.
-docker_compose_cli_plugin_paths() {
-   local config_file="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
-   local dir in_extra line
-
-   print -r -- "${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose"
-   [[ -r "$config_file" ]] || return 0
-
-   while IFS= read -r line; do
-      if [[ "$line" == *'"cliPluginsExtraDirs"'* ]]; then
-         in_extra=1
-         line="${line#*\"cliPluginsExtraDirs\"}"
-      fi
-      (( in_extra )) || continue
-
-      while [[ "$line" == *'"'* ]]; do
-         line="${line#*\"}"
-         dir="${line%%\"*}"
-         line="${line#*\"}"
-         [[ -n "$dir" ]] && print -r -- "$dir/docker-compose"
-      done
-      [[ "$line" == *']'* ]] && break
-   done < "$config_file"
-}
-
-# Return success when a Compose v2 plugin executable is discoverable.
-has_docker_compose_cli_plugin() {
-   local plugin
-   while IFS= read -r plugin; do
-      [[ -x "$plugin" ]] && return 0
-   done < <(docker_compose_cli_plugin_paths)
-
-   for plugin in \
-      "/usr/local/lib/docker/cli-plugins/docker-compose" \
-      "/usr/local/libexec/docker/cli-plugins/docker-compose" \
-      "/usr/lib/docker/cli-plugins/docker-compose" \
-      "/usr/libexec/docker/cli-plugins/docker-compose"; do
-      [[ -x "$plugin" ]] && return 0
-   done
-   return 1
-}
-
-if command -v docker-compose >/dev/null 2>&1 || has_docker_compose_cli_plugin; then
+if command -v docker-compose >/dev/null 2>&1 \
+   || { whence -w has_docker_compose_cli_plugin >/dev/null 2>&1 && has_docker_compose_cli_plugin; }; then
    plugins+=(docker-compose)
 fi
-unfunction has_docker_compose_cli_plugin docker_compose_cli_plugin_paths
 
 if [[ "$OS" == "macos" ]]; then
    plugins+=(

--- a/.zshrc
+++ b/.zshrc
@@ -66,8 +66,6 @@ plugins=(
 
 if command -v docker-compose >/dev/null 2>&1; then
    plugins+=(docker-compose)
-elif command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
-   plugins+=(docker-compose)
 fi
 
 if [[ "$OS" == "macos" ]]; then

--- a/.zshrc
+++ b/.zshrc
@@ -67,7 +67,7 @@ plugins=(
 has_docker_compose_cli_plugin() {
    local plugin
    for plugin in \
-      "$HOME/.docker/cli-plugins/docker-compose" \
+      "${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose" \
       "/usr/local/lib/docker/cli-plugins/docker-compose" \
       "/usr/local/libexec/docker/cli-plugins/docker-compose" \
       "/usr/lib/docker/cli-plugins/docker-compose" \

--- a/.zshrc
+++ b/.zshrc
@@ -64,10 +64,39 @@ plugins=(
    zsh-syntax-highlighting
 )
 
+# Print candidate Compose v2 plugin executables without invoking Docker.
+docker_compose_cli_plugin_paths() {
+   local config_file="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+   local dir in_extra line
+
+   print -r -- "${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose"
+   [[ -r "$config_file" ]] || return 0
+
+   while IFS= read -r line; do
+      if [[ "$line" == *'"cliPluginsExtraDirs"'* ]]; then
+         in_extra=1
+         line="${line#*\"cliPluginsExtraDirs\"}"
+      fi
+      (( in_extra )) || continue
+
+      while [[ "$line" == *'"'* ]]; do
+         line="${line#*\"}"
+         dir="${line%%\"*}"
+         line="${line#*\"}"
+         [[ -n "$dir" ]] && print -r -- "$dir/docker-compose"
+      done
+      [[ "$line" == *']'* ]] && break
+   done < "$config_file"
+}
+
+# Return success when a Compose v2 plugin executable is discoverable.
 has_docker_compose_cli_plugin() {
    local plugin
+   while IFS= read -r plugin; do
+      [[ -x "$plugin" ]] && return 0
+   done < <(docker_compose_cli_plugin_paths)
+
    for plugin in \
-      "${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose" \
       "/usr/local/lib/docker/cli-plugins/docker-compose" \
       "/usr/local/libexec/docker/cli-plugins/docker-compose" \
       "/usr/lib/docker/cli-plugins/docker-compose" \
@@ -80,7 +109,7 @@ has_docker_compose_cli_plugin() {
 if command -v docker-compose >/dev/null 2>&1 || has_docker_compose_cli_plugin; then
    plugins+=(docker-compose)
 fi
-unfunction has_docker_compose_cli_plugin
+unfunction has_docker_compose_cli_plugin docker_compose_cli_plugin_paths
 
 if [[ "$OS" == "macos" ]]; then
    plugins+=(

--- a/.zshrc
+++ b/.zshrc
@@ -64,9 +64,23 @@ plugins=(
    zsh-syntax-highlighting
 )
 
-if command -v docker-compose >/dev/null 2>&1; then
+has_docker_compose_cli_plugin() {
+   local plugin
+   for plugin in \
+      "$HOME/.docker/cli-plugins/docker-compose" \
+      "/usr/local/lib/docker/cli-plugins/docker-compose" \
+      "/usr/local/libexec/docker/cli-plugins/docker-compose" \
+      "/usr/lib/docker/cli-plugins/docker-compose" \
+      "/usr/libexec/docker/cli-plugins/docker-compose"; do
+      [[ -x "$plugin" ]] && return 0
+   done
+   return 1
+}
+
+if command -v docker-compose >/dev/null 2>&1 || has_docker_compose_cli_plugin; then
    plugins+=(docker-compose)
 fi
+unfunction has_docker_compose_cli_plugin
 
 if [[ "$OS" == "macos" ]]; then
    plugins+=(

--- a/.zshrc_custom/alias.zsh
+++ b/.zshrc_custom/alias.zsh
@@ -83,18 +83,10 @@ if [[ "$(uname)" == "Darwin" && -x "/Applications/MacUpdater.app/Contents/Resour
 fi
 
 # Copilot CLI (lazy wrappers avoid running gh during shell startup)
-if command -v copilot_what-the-shell >/dev/null 2>&1; then
-  alias wts='copilot_what-the-shell'
-fi
-if command -v copilot_shell_suggest >/dev/null 2>&1; then
-  alias '??'='copilot_shell_suggest'
-fi
-if command -v copilot_git_suggest >/dev/null 2>&1; then
-  alias "git?"='copilot_git_suggest'
-fi
-if command -v copilot_gh_suggest >/dev/null 2>&1; then
-  alias 'gh?'='copilot_gh_suggest'
-fi
+alias wts='copilot_what-the-shell'
+alias '??'='copilot_shell_suggest'
+alias "git?"='copilot_git_suggest'
+alias 'gh?'='copilot_gh_suggest'
 
 # Fun
 if command -v pbcopy >/dev/null 2>&1; then

--- a/.zshrc_custom/alias.zsh
+++ b/.zshrc_custom/alias.zsh
@@ -82,9 +82,8 @@ if [[ "$(uname)" == "Darwin" && -x "/Applications/MacUpdater.app/Contents/Resour
   alias macupdater='/Applications/MacUpdater.app/Contents/Resources/macupdater_client'
 fi
 
-# Copilot CLI
-if command -v gh >/dev/null 2>&1 \
-  && gh extension list 2>/dev/null | grep -Eq '^gh[[:space:]]+copilot([[:space:]]|$)'; then
+# Copilot CLI (lazy wrappers avoid running gh during shell startup)
+if command -v gh >/dev/null 2>&1; then
   alias wts='copilot_what-the-shell'
   alias '??'='copilot_shell_suggest'
   alias "git?"='copilot_git_suggest'

--- a/.zshrc_custom/alias.zsh
+++ b/.zshrc_custom/alias.zsh
@@ -83,10 +83,16 @@ if [[ "$(uname)" == "Darwin" && -x "/Applications/MacUpdater.app/Contents/Resour
 fi
 
 # Copilot CLI (lazy wrappers avoid running gh during shell startup)
-if command -v gh >/dev/null 2>&1; then
+if command -v copilot_what-the-shell >/dev/null 2>&1; then
   alias wts='copilot_what-the-shell'
+fi
+if command -v copilot_shell_suggest >/dev/null 2>&1; then
   alias '??'='copilot_shell_suggest'
+fi
+if command -v copilot_git_suggest >/dev/null 2>&1; then
   alias "git?"='copilot_git_suggest'
+fi
+if command -v copilot_gh_suggest >/dev/null 2>&1; then
   alias 'gh?'='copilot_gh_suggest'
 fi
 

--- a/.zshrc_custom/debian-exports
+++ b/.zshrc_custom/debian-exports
@@ -16,10 +16,39 @@ fi
 
 # Many Debian Docker hosts install the Compose v2 plugin rather than the
 # legacy docker-compose binary.
+# Print candidate Compose v2 plugin executables without invoking Docker.
+docker_compose_cli_plugin_paths() {
+  local config_file="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+  local dir in_extra line
+
+  print -r -- "${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose"
+  [[ -r "$config_file" ]] || return 0
+
+  while IFS= read -r line; do
+    if [[ "$line" == *'"cliPluginsExtraDirs"'* ]]; then
+      in_extra=1
+      line="${line#*\"cliPluginsExtraDirs\"}"
+    fi
+    (( in_extra )) || continue
+
+    while [[ "$line" == *'"'* ]]; do
+      line="${line#*\"}"
+      dir="${line%%\"*}"
+      line="${line#*\"}"
+      [[ -n "$dir" ]] && print -r -- "$dir/docker-compose"
+    done
+    [[ "$line" == *']'* ]] && break
+  done < "$config_file"
+}
+
+# Return success when a Compose v2 plugin executable is discoverable.
 has_docker_compose_cli_plugin() {
   local plugin
+  while IFS= read -r plugin; do
+    [[ -x "$plugin" ]] && return 0
+  done < <(docker_compose_cli_plugin_paths)
+
   for plugin in \
-    "${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose" \
     "/usr/local/lib/docker/cli-plugins/docker-compose" \
     "/usr/local/libexec/docker/cli-plugins/docker-compose" \
     "/usr/lib/docker/cli-plugins/docker-compose" \
@@ -36,6 +65,6 @@ if ! command -v docker-compose >/dev/null 2>&1 \
     docker compose "$@"
   }
 fi
-unfunction has_docker_compose_cli_plugin
+unfunction has_docker_compose_cli_plugin docker_compose_cli_plugin_paths
 
 export PATH

--- a/.zshrc_custom/debian-exports
+++ b/.zshrc_custom/debian-exports
@@ -16,55 +16,23 @@ fi
 
 # Many Debian Docker hosts install the Compose v2 plugin rather than the
 # legacy docker-compose binary.
-# Print candidate Compose v2 plugin executables without invoking Docker.
-docker_compose_cli_plugin_paths() {
-  local config_file="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
-  local dir in_extra line
-
-  print -r -- "${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose"
-  [[ -r "$config_file" ]] || return 0
-
-  while IFS= read -r line; do
-    if [[ "$line" == *'"cliPluginsExtraDirs"'* ]]; then
-      in_extra=1
-      line="${line#*\"cliPluginsExtraDirs\"}"
-    fi
-    (( in_extra )) || continue
-
-    while [[ "$line" == *'"'* ]]; do
-      line="${line#*\"}"
-      dir="${line%%\"*}"
-      line="${line#*\"}"
-      [[ -n "$dir" ]] && print -r -- "$dir/docker-compose"
-    done
-    [[ "$line" == *']'* ]] && break
-  done < "$config_file"
-}
-
-# Return success when a Compose v2 plugin executable is discoverable.
-has_docker_compose_cli_plugin() {
-  local plugin
-  while IFS= read -r plugin; do
-    [[ -x "$plugin" ]] && return 0
-  done < <(docker_compose_cli_plugin_paths)
-
-  for plugin in \
-    "/usr/local/lib/docker/cli-plugins/docker-compose" \
-    "/usr/local/libexec/docker/cli-plugins/docker-compose" \
-    "/usr/lib/docker/cli-plugins/docker-compose" \
-    "/usr/libexec/docker/cli-plugins/docker-compose"; do
-    [[ -x "$plugin" ]] && return 0
-  done
-  return 1
-}
+if ! whence -w has_docker_compose_cli_plugin >/dev/null 2>&1; then
+  compose_detection_file="${ZSH_CUSTOM:-$HOME/.zshrc_custom}/docker-compose-detection.zsh"
+  [[ -r "$compose_detection_file" ]] && source "$compose_detection_file"
+  unset compose_detection_file
+fi
 
 if ! command -v docker-compose >/dev/null 2>&1 \
   && command -v docker >/dev/null 2>&1 \
+  && whence -w has_docker_compose_cli_plugin >/dev/null 2>&1 \
   && has_docker_compose_cli_plugin; then
   docker-compose() {
+    if ! docker compose version >/dev/null 2>&1; then
+      print -u2 "Docker Compose v2 is not available through 'docker compose'."
+      return 127
+    fi
     docker compose "$@"
   }
 fi
-unfunction has_docker_compose_cli_plugin docker_compose_cli_plugin_paths
 
 export PATH

--- a/.zshrc_custom/debian-exports
+++ b/.zshrc_custom/debian-exports
@@ -16,11 +16,26 @@ fi
 
 # Many Debian Docker hosts install the Compose v2 plugin rather than the
 # legacy docker-compose binary.
+has_docker_compose_cli_plugin() {
+  local plugin
+  for plugin in \
+    "$HOME/.docker/cli-plugins/docker-compose" \
+    "/usr/local/lib/docker/cli-plugins/docker-compose" \
+    "/usr/local/libexec/docker/cli-plugins/docker-compose" \
+    "/usr/lib/docker/cli-plugins/docker-compose" \
+    "/usr/libexec/docker/cli-plugins/docker-compose"; do
+    [[ -x "$plugin" ]] && return 0
+  done
+  return 1
+}
+
 if ! command -v docker-compose >/dev/null 2>&1 \
-  && command -v docker >/dev/null 2>&1; then
+  && command -v docker >/dev/null 2>&1 \
+  && has_docker_compose_cli_plugin; then
   docker-compose() {
     docker compose "$@"
   }
 fi
+unfunction has_docker_compose_cli_plugin
 
 export PATH

--- a/.zshrc_custom/debian-exports
+++ b/.zshrc_custom/debian-exports
@@ -19,7 +19,7 @@ fi
 has_docker_compose_cli_plugin() {
   local plugin
   for plugin in \
-    "$HOME/.docker/cli-plugins/docker-compose" \
+    "${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose" \
     "/usr/local/lib/docker/cli-plugins/docker-compose" \
     "/usr/local/libexec/docker/cli-plugins/docker-compose" \
     "/usr/lib/docker/cli-plugins/docker-compose" \

--- a/.zshrc_custom/debian-exports
+++ b/.zshrc_custom/debian-exports
@@ -27,10 +27,6 @@ if ! command -v docker-compose >/dev/null 2>&1 \
   && whence -w has_docker_compose_cli_plugin >/dev/null 2>&1 \
   && has_docker_compose_cli_plugin; then
   docker-compose() {
-    if ! docker compose version >/dev/null 2>&1; then
-      print -u2 "Docker Compose v2 is not available through 'docker compose'."
-      return 127
-    fi
     docker compose "$@"
   }
 fi

--- a/.zshrc_custom/debian-exports
+++ b/.zshrc_custom/debian-exports
@@ -17,8 +17,7 @@ fi
 # Many Debian Docker hosts install the Compose v2 plugin rather than the
 # legacy docker-compose binary.
 if ! command -v docker-compose >/dev/null 2>&1 \
-  && command -v docker >/dev/null 2>&1 \
-  && docker compose version >/dev/null 2>&1; then
+  && command -v docker >/dev/null 2>&1; then
   docker-compose() {
     docker compose "$@"
   }

--- a/.zshrc_custom/docker-compose-detection.zsh
+++ b/.zshrc_custom/docker-compose-detection.zsh
@@ -1,0 +1,41 @@
+# Print candidate Compose v2 plugin executables without invoking Docker.
+docker_compose_cli_plugin_paths() {
+  local config_file="${DOCKER_CONFIG:-$HOME/.docker}/config.json"
+  local dir in_extra line
+
+  print -r -- "${DOCKER_CONFIG:-$HOME/.docker}/cli-plugins/docker-compose"
+  [[ -r "$config_file" ]] || return 0
+
+  while IFS= read -r line; do
+    if [[ "$line" == *'"cliPluginsExtraDirs"'* ]]; then
+      in_extra=1
+      line="${line#*\"cliPluginsExtraDirs\"}"
+    fi
+    (( in_extra )) || continue
+
+    while [[ "$line" == *'"'* ]]; do
+      line="${line#*\"}"
+      dir="${line%%\"*}"
+      line="${line#*\"}"
+      [[ -n "$dir" ]] && print -r -- "$dir/docker-compose"
+    done
+    [[ "$line" == *']'* ]] && break
+  done < "$config_file"
+}
+
+# Return success when a Compose v2 plugin executable is discoverable.
+has_docker_compose_cli_plugin() {
+  local plugin
+  while IFS= read -r plugin; do
+    [[ -x "$plugin" ]] && return 0
+  done < <(docker_compose_cli_plugin_paths)
+
+  for plugin in \
+    "/usr/local/lib/docker/cli-plugins/docker-compose" \
+    "/usr/local/libexec/docker/cli-plugins/docker-compose" \
+    "/usr/lib/docker/cli-plugins/docker-compose" \
+    "/usr/libexec/docker/cli-plugins/docker-compose"; do
+    [[ -x "$plugin" ]] && return 0
+  done
+  return 1
+}

--- a/.zshrc_custom/functions.zsh
+++ b/.zshrc_custom/functions.zsh
@@ -111,6 +111,7 @@ if [[ "$(uname)" == "Darwin" ]]; then
                 mandoc -T pdf "$(/usr/bin/man -w "$@")" | open -fa Preview
         }
 fi
+# Run GitHub Copilot suggestions only after invocation-time availability checks.
 _gh_copilot_suggest() {
         if ! command -v gh >/dev/null 2>&1; then
                 print -u2 "gh is required for Copilot suggestions."
@@ -123,6 +124,7 @@ _gh_copilot_suggest() {
         gh copilot suggest "$@"
 }
 
+# Suggest a shell command with GitHub Copilot.
 copilot_what-the-shell() {
         _gh_copilot_suggest -t shell "$@"
 }
@@ -137,6 +139,7 @@ copilot_gh_suggest() {
         _gh_copilot_suggest -t gh "$@"
 }
 
+# Suggest a shell command with GitHub Copilot.
 copilot_shell_suggest() {
         _gh_copilot_suggest -t shell "$@"
 }

--- a/.zshrc_custom/functions.zsh
+++ b/.zshrc_custom/functions.zsh
@@ -111,18 +111,34 @@ if [[ "$(uname)" == "Darwin" ]]; then
                 mandoc -T pdf "$(/usr/bin/man -w "$@")" | open -fa Preview
         }
 fi
+_gh_copilot_suggest() {
+        if ! command -v gh >/dev/null 2>&1; then
+                print -u2 "gh is required for Copilot suggestions."
+                return 127
+        fi
+        if ! gh copilot --help >/dev/null 2>&1; then
+                print -u2 "GitHub CLI Copilot is unavailable. Install it with: gh extension install github/gh-copilot"
+                return 127
+        fi
+        gh copilot suggest "$@"
+}
+
+copilot_what-the-shell() {
+        _gh_copilot_suggest -t shell "$@"
+}
+
 # Function to handle Git command suggestions
 copilot_git_suggest() {
-        gh copilot suggest -t git "$@"
+        _gh_copilot_suggest -t git "$@"
 }
 
 # Function to handle GitHub CLI command suggestions
 copilot_gh_suggest() {
-        gh copilot suggest -t gh "$@"
+        _gh_copilot_suggest -t gh "$@"
 }
 
 copilot_shell_suggest() {
-        gh copilot suggest -t shell "$@"
+        _gh_copilot_suggest -t shell "$@"
 }
 
 codex() {

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -14,6 +14,7 @@ zsh_files=(
   .zshenv
   .zshrc
   .zshrc_custom/alias.zsh
+  .zshrc_custom/docker-compose-detection.zsh
   .zshrc_custom/functions.zsh
   .zshrc_custom/macos-exports
   .zshrc_custom/debian-exports


### PR DESCRIPTION
### Motivation
- The startup scripts executed `docker compose version` and `gh extension list` during zsh initialization, which can run PATH-planted binaries from user-writable directories and lead to code execution at shell startup. 
- The change aims to remove any probe that invokes external CLIs during initialization while preserving the existing behavior when the real tools are invoked interactively.

### Description
- Removed the fallback branch in `.zshrc` that ran `docker compose version` and now only adds `docker-compose` to `plugins` when `docker-compose` is directly resolvable via `command -v`. 
- Replaced the `gh` startup probe in `.zshrc_custom/alias.zsh` so aliases are gated by `command -v gh` only, avoiding `gh extension list` execution at startup. 
- Simplified the Debian fallback in `.zshrc_custom/debian-exports` to define a `docker-compose()` wrapper only when `docker` exists and `docker-compose` does not, removing the runtime `docker compose version` check. 
- Behavior is preserved for interactive use because command execution is deferred until the user actually invokes the tools or the aliases.

### Testing
- Ran `rg -n "docker compose version|gh extension list" .zshrc .zshrc_custom/alias.zsh .zshrc_custom/debian-exports` and confirmed no matches, indicating startup probes were removed. 
- Inspected the updated files to verify the conditional logic now uses non-executing `command -v` checks and that the `docker-compose()` wrapper is only defined based on `command -v docker`. 
- Verified the repository shows the three intended files modified to implement this remediation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fab47d3188322ad310792ec077d9d)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shell-config only: reduces startup attack surface; Compose plugin detection is path/heuristic-based and may differ slightly from a live `docker compose version` check.
> 
> **Overview**
> This PR **stops running `docker` and `gh` during zsh startup** (e.g. `docker compose version` and `gh extension list`) so a malicious binary on `PATH` cannot execute at shell init, while keeping interactive behavior when you actually use Compose or Copilot.
> 
> **Docker Compose:** A new `docker-compose-detection.zsh` discovers the Compose v2 **CLI plugin by executable paths** (default `~/.docker/cli-plugins`, `cliPluginsExtraDirs` in `config.json`, and common system plugin dirs) **without calling Docker**. `.zshrc` sources it early and only adds the `docker-compose` OMZ plugin when `docker-compose` is on `PATH` or `has_docker_compose_cli_plugin` succeeds. **Debian** uses the same helper to define a `docker-compose()` wrapper that forwards to `docker compose` only when the legacy binary is missing but a plugin is found.
> 
> **GitHub Copilot:** Copilot aliases in `alias.zsh` are **always defined** (no startup `gh` probe). Suggestion helpers in `functions.zsh` go through `_gh_copilot_suggest`, which checks `gh` and `gh copilot` **when you invoke** a command and prints clear errors if unavailable.
> 
> `scripts/check.sh` now syntax-checks the new zsh file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17749ba559b8e66cfa58049c47bb3a69cebbd058. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved detection of Docker Compose availability to recognize CLI plugin installations for smoother startup behavior.
  * Relaxed conditions for defining the Docker Compose wrapper so initialization is less strict.
  * Copilot-related aliases are now available at shell startup as lightweight wrappers to their helpers.

* **Bug Fixes**
  * Copilot suggestion commands now route through a shared checker that emits clear errors if the underlying tool is unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/27?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->