### PR TITLE
Add private superassistant local context hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .claude/skills/*
 .copilot/skills/*
 .config/agent-skills/skills/.DS_Store
+superassistant/AGENTS.local.md

--- a/superassistant/AGENTS.md
+++ b/superassistant/AGENTS.md
@@ -4,6 +4,8 @@ This file is public, synced, and repo-agnostic. It defines cross-repo personal-o
 
 Keep this file free of secrets, private links, account IDs, credentials, tokens, machine-specific paths, sensitive host details, and project-specific workflow. Put private or host-specific values in ignored local files or the authoritative source system.
 
+If `AGENTS.local.md` exists beside this file, read it before personal-operations work. Treat it as private, ignored local context. Never quote, commit, sync, or expose its contents unless the user explicitly asks.
+
 ## Instruction Hierarchy
 
 - When a repository under this folder provides its own `AGENTS.md` or nested `AGENTS.md`, treat the more local file as the source of truth for repo-specific workflow, tooling, validation, GitHub process, and coding conventions.


### PR DESCRIPTION
## Summary
- teach superassistant AGENTS.md to read a private AGENTS.local.md when present
- ignore superassistant/AGENTS.local.md so host-local private context is not committed

## Validation
- git diff --check
- verified superassistant/AGENTS.local.md is ignored locally
- verified live symlink resolves to the iCloud-backed private file on this host

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and ignore-rule only; no runtime code, auth, or data paths change.
> 
> **Overview**
> Adds a **private local agent context** pattern for the synced `superassistant` workspace: agents are told to read optional `AGENTS.local.md` beside the public `AGENTS.md` before personal-operations work, treat it as private, and not quote or sync it unless the user asks.
> 
> **`.gitignore`** now excludes `superassistant/AGENTS.local.md` so host-specific private guidance (e.g. via symlink) cannot be committed with the public dotfiles repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0e4f72b8aece86e1b0f6d95d99a578779ab75bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->