### PR TITLE
[codex] Load CODEX_HOME from zshenv

### DIFF
--- a/.zshenv
+++ b/.zshenv
@@ -7,10 +7,7 @@ typeset -U path PATH
 [[ -d "$HOME/.local/bin" ]] && path=("$HOME/.local/bin" $path)
 [[ -d "$HOME/.zshrc_custom/bin" ]] && path=("$HOME/.zshrc_custom/bin" $path)
 
-if [[ -z "$CODEX_HOME" ]]; then
-        [[ -d "$HOME/.codex-home" ]] && CODEX_HOME="$HOME/.codex-home" || CODEX_HOME="$HOME/.codex"
-fi
-export CODEX_HOME
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 export PATH
 
 [[ -f "$HOME/.zshenv.local" ]] && source "$HOME/.zshenv.local"

--- a/.zshenv
+++ b/.zshenv
@@ -7,7 +7,10 @@ typeset -U path PATH
 [[ -d "$HOME/.local/bin" ]] && path=("$HOME/.local/bin" $path)
 [[ -d "$HOME/.zshrc_custom/bin" ]] && path=("$HOME/.zshrc_custom/bin" $path)
 
-export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
+if [[ -z "$CODEX_HOME" ]]; then
+        [[ -d "$HOME/.codex-home" ]] && CODEX_HOME="$HOME/.codex-home" || CODEX_HOME="$HOME/.codex"
+fi
+export CODEX_HOME
 export PATH
 
 [[ -f "$HOME/.zshenv.local" ]] && source "$HOME/.zshenv.local"

--- a/.zshenv
+++ b/.zshenv
@@ -7,6 +7,7 @@ typeset -U path PATH
 [[ -d "$HOME/.local/bin" ]] && path=("$HOME/.local/bin" $path)
 [[ -d "$HOME/.zshrc_custom/bin" ]] && path=("$HOME/.zshrc_custom/bin" $path)
 
+export CODEX_HOME="${CODEX_HOME:-$HOME/.codex}"
 export PATH
 
 [[ -f "$HOME/.zshenv.local" ]] && source "$HOME/.zshenv.local"

--- a/.zshrc_custom/functions.zsh
+++ b/.zshrc_custom/functions.zsh
@@ -144,23 +144,6 @@ copilot_shell_suggest() {
         _gh_copilot_suggest -t shell "$@"
 }
 
-codex() {
-        if [ -n "$CODEX_HOME" ]; then
-                command codex "$@"
-                return
-        fi
-
-        if [ "$PWD" = "$HOME" ]; then
-                local codex_home="$HOME/.codex-home"
-                if [ ! -d "$codex_home" ]; then
-                        codex_home="$HOME/.codex"
-                fi
-                CODEX_HOME="$codex_home" command codex "$@"
-        else
-                command codex "$@"
-        fi
-}
-
 # Fun
 flip() {
         if command -v pbcopy >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- Default `CODEX_HOME` to `$HOME/.codex` from `.zshenv` so non-interactive zsh/Codex automation sessions see it
- Remove the old `codex()` shell wrapper workaround that special-cased `$HOME/.codex-home`
- Keep explicit overrides available through the environment or ignored `~/.zshenv.local`

## Validation
- `zsh -n ~/.zshenv`
- `zsh -n ~/.zshrc_custom/functions.zsh`
- `zsh -c 'printf "%s\n" "$CODEX_HOME"'` -> `/Users/pablovalero/.codex`
- `CODEX_HOME=/custom/codex zsh -c 'printf "%s\n" "$CODEX_HOME"'` -> `/custom/codex`
- `zsh -ic 'whence -w codex'` -> `codex: command`
- `git --git-dir=/Users/pablovalero/.local/share/yadm/repo.git --work-tree=/Users/pablovalero diff --cached --check` before commit

## Notes
- `.codex-home` was a personal wrapper workaround introduced in this repo, not an official Codex path. The directory does not exist on this host.
- Added shared Craft Host Messages for Kakarot, Broly, and Tapion to pull dotfiles and verify `CODEX_HOME` on each Codex host.
- `codex-automation` label was not present in this repo; applied `codex` only.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small shell startup change; wrong `CODEX_HOME` could mispoint Codex config, but behavior is simpler and overridable via env or `~/.zshenv.local`.
> 
> **Overview**
> **`CODEX_HOME` is now set globally in `.zshenv`** (defaulting to `$HOME/.codex` when unset) so non-interactive and automation shells see it before `PATH` and optional `~/.zshenv.local` overrides.
> 
> The interactive **`codex()` shell wrapper is removed** from `functions.zsh`, along with its behavior of picking `~/.codex-home` vs `~/.codex` when run from `$HOME` and only setting `CODEX_HOME` at invoke time. Codex is invoked via the normal `codex` on `PATH` with the environment from `.zshenv`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c16492512413dcc0bdf6d3f270c93a5a92a4a6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Initialize and export CODEX_HOME with a default of $HOME/.codex when unset, and export it early (before PATH and local config are processed) to ensure a consistent environment.
  * Removed the legacy codex() shell function and its selection logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pevd950/dotfiles/pull/31?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

