### PR TITLE
Use portable Match exec quoting

### DIFF
--- a/scripts/setup-1password-dev.zsh
+++ b/scripts/setup-1password-dev.zsh
@@ -177,7 +177,7 @@ ensure_ssh_config_identity_agent() {
     printf "# Keep this include before other Host or Match blocks in ~/.ssh/config.\n"
     printf "# Use the GUI-backed 1Password SSH agent only for local sessions.\n"
     printf "# Inbound SSH sessions are unattended; let forwarded agents or host-specific SSH config handle them.\n"
-    printf '%s\n' 'Match exec "test -z \"${SSH_CONNECTION}${SSH_CLIENT}\""'
+    printf '%s\n' 'Match exec "test x${SSH_CONNECTION}${SSH_CLIENT} = x"'
     printf "  IdentityAgent \"%s\"\n" "$agent_path"
     printf "Match all\n"
   } > "$include_file"


### PR DESCRIPTION
## Summary
- replace the generated `Match exec` shell test with a parser-safe form that avoids escaped inner quotes
- keep the same behavior: local shells get the 1Password IdentityAgent, inbound SSH via `SSH_CONNECTION` or `SSH_CLIENT` does not

## Why
A PR #34 review reported that the escaped inner quotes can be parsed as invalid Match criteria on some OpenSSH/macOS configurations. This form avoids nested quoting while preserving the unattended-SSH boundary.

## Validation
- `./scripts/check.sh`
- `git diff --check`
- synthetic `ssh -F <config> -G github.com` probe:
  - local session resolves the 1Password IdentityAgent
  - `SSH_CONNECTION` session resolves `identityagent missing`
  - `SSH_CLIENT` session resolves `identityagent missing`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change to generated SSH config text in a dev setup script; same runtime behavior, lower parser breakage risk.
> 
> **Overview**
> Updates the **generated** `~/.ssh/config.d/1password-agent.conf` `Match exec` test in `scripts/setup-1password-dev.zsh` so OpenSSH parsers accept it on more macOS/OpenSSH builds.
> 
> The script now emits `test x${SSH_CONNECTION}${SSH_CLIENT} = x` instead of a `test -z` form with escaped inner quotes. **Behavior is unchanged:** local shells still get the 1Password `IdentityAgent`; inbound SSH (when `SSH_CONNECTION` or `SSH_CLIENT` is set) still skips it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db042a547a65518238f760096e2632f4ec80c7ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->