### PR TITLE
Simplify global Codex instructions

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,15 +1,7 @@
-Keep global Codex instructions repo-agnostic and free of project-specific workflow.
+Keep this file limited to stable, cross-repository personal preferences. More local `AGENTS.md` instructions take precedence.
 
-Use this file only for cross-repo personal preferences that should apply everywhere.
+For Todoist, do not default new tasks to Inbox. Inspect existing projects, sections, and labels when practical and choose the best fit. Use Inbox only when no suitable location exists or the user explicitly requests it.
 
-For Todoist, do not default new tasks to Inbox. Inspect existing projects/sections/labels when practical and choose the best fit; use Inbox only when no suitable project exists or the user explicitly asks for it.
+For Craft, treat it as a rich document system rather than a Markdown sink. Use hierarchy, structured blocks, nested pages, callouts, tables, and light visual formatting when they materially improve readability.
 
-For Craft, treat it as a rich document system rather than a plain Markdown sink. Use structured blocks, hierarchy, nested pages, callouts, tables, and light visual formatting when they make notes easier to scan.
-
-Git operations must stay non-interactive. Never run plain `git rebase --continue` in automation or agent sessions because it may open an editor and hang; use an explicit no-editor form such as `GIT_EDITOR=true git rebase --continue`. Apply the same rule to other Git commands that would otherwise launch an editor.
-
-When a repository provides `AGENTS.md` or nested `AGENTS.md` files, treat those as the source of truth for repo-specific workflow, tooling, validation, GitHub process, and coding conventions.
-
-If guidance conflicts, prefer the more local repository instruction over this global file.
-
-Avoid duplicating repository instructions here. Keep this file short, stable, and safe to track in dotfiles.
+Keep Git operations non-interactive. Never run plain `git rebase --continue` in an agent session because it may open an editor and hang. Use an explicit no-editor form such as `GIT_EDITOR=true git rebase --continue`, and apply the same principle to other commands that might launch an editor.


### PR DESCRIPTION
## What changed

- Consolidated repeated guidance about keeping global Codex instructions repository-agnostic
- Preserved the Todoist, Craft, and non-interactive Git preferences
- Clarified that more local `AGENTS.md` files take precedence

## Why

Codex already discovers repository-specific instruction files, so the global file only needs stable personal preferences and an explicit conflict rule. This reduces prompt duplication while preserving the behavior that materially differs from Codex defaults.

## Validation

- Verified the updated `.codex/AGENTS.md` contents on the PR branch
- Documentation-only change; no automated tests required

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance for maintaining stable, cross-repository preferences.
  * Updated task organization recommendations to favor appropriate existing locations over a default Inbox.
  * Refined document-formatting guidance to support structured, readable content.
  * Simplified non-interactive Git operation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->