### PR TITLE
Keep Craft API credentials on same-origin HTTPS requests

### DIFF
--- a/.agents/skills/productivity/craft-api/SKILL.md
+++ b/.agents/skills/productivity/craft-api/SKILL.md
@@ -39,6 +39,7 @@ python3 "$SKILL_DIR/scripts/craft_api.py" GET /documents
 
 Resolve the script relative to this `SKILL.md` file. Do not assume the current working directory is the skill folder, and do not hard-code a user's home path.
 When another skill needs Craft API access, call this helper instead of reimplementing HTTP in shell, Python, or curl unless you are deliberately debugging the helper itself.
+The helper requires an HTTPS base URL without userinfo. It follows redirects only when the scheme, hostname, and effective port remain exactly same-origin; other redirects fail without forwarding either supported credential header.
 
 For manual `curl`, prefer:
 

--- a/.agents/skills/productivity/craft-api/scripts/craft_api.py
+++ b/.agents/skills/productivity/craft-api/scripts/craft_api.py
@@ -5,12 +5,54 @@ import json
 import os
 import math
 import sys
+from typing import Optional, Tuple
 import urllib.error
 import urllib.parse
 import urllib.request
 
 
 MAX_TIMEOUT_SECONDS = 300.0
+
+
+class UnsafeRedirectError(Exception):
+    pass
+
+
+def https_origin(url: str) -> Tuple[str, str, int]:
+    parsed_url = urllib.parse.urlsplit(url)
+    if parsed_url.scheme.lower() != "https" or not parsed_url.netloc:
+        raise ValueError("URL must be absolute and use HTTPS")
+    if parsed_url.username is not None or parsed_url.password is not None:
+        raise ValueError("URL must not include userinfo")
+    if parsed_url.hostname is None:
+        raise ValueError("URL must include a hostname")
+    port = parsed_url.port or 443
+    return ("https", parsed_url.hostname.lower(), port)
+
+
+class SameOriginRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def __init__(self, trusted_origin: Tuple[str, str, int]) -> None:
+        super().__init__()
+        self.trusted_origin = trusted_origin
+
+    def redirect_request(
+        self,
+        request: urllib.request.Request,
+        file_pointer,
+        code: int,
+        message: str,
+        headers,
+        new_url: str,
+    ) -> Optional[urllib.request.Request]:
+        try:
+            redirect_origin = https_origin(new_url)
+        except ValueError as error:
+            raise UnsafeRedirectError(str(error)) from error
+        if redirect_origin != self.trusted_origin:
+            raise UnsafeRedirectError("redirect target is outside the trusted origin")
+        return super().redirect_request(
+            request, file_pointer, code, message, headers, new_url
+        )
 
 
 def main() -> int:
@@ -38,9 +80,17 @@ def main() -> int:
     if any(ord(ch) < 32 or ord(ch) == 127 for ch in api_key):
         print("CRAFT_API_KEY contains invalid control characters", file=sys.stderr)
         return 2
-    parsed_base_url = urllib.parse.urlsplit(base_url)
-    if parsed_base_url.scheme not in {"http", "https"} or not parsed_base_url.netloc:
-        print("CRAFT_API_BASE_URL must be an absolute http(s) URL", file=sys.stderr)
+    try:
+        parsed_base_url = urllib.parse.urlsplit(base_url)
+        if parsed_base_url.scheme.lower() != "https":
+            print("CRAFT_API_BASE_URL must use HTTPS", file=sys.stderr)
+            return 2
+        if parsed_base_url.username is not None or parsed_base_url.password is not None:
+            print("CRAFT_API_BASE_URL must not include userinfo", file=sys.stderr)
+            return 2
+        trusted_origin = https_origin(base_url)
+    except ValueError as error:
+        print(f"CRAFT_API_BASE_URL is invalid: {error}", file=sys.stderr)
         return 2
 
     path = args.path if args.path.startswith("/") else f"/{args.path}"
@@ -104,12 +154,16 @@ def main() -> int:
         headers["x-craft-api-key"] = api_key
 
     request = urllib.request.Request(url, data=body, headers=headers, method=args.method)
+    opener = urllib.request.build_opener(SameOriginRedirectHandler(trusted_origin))
     try:
-        with urllib.request.urlopen(request, timeout=args.timeout) as response:
+        with opener.open(request, timeout=args.timeout) as response:
             payload = response.read()
             sys.stdout.buffer.write(payload)
             if sys.stdout.isatty() and not payload.endswith(b"\n"):
                 sys.stdout.write("\n")
+    except UnsafeRedirectError as error:
+        sys.stderr.write(f"Craft API blocked unsafe redirect: {error}\n")
+        return 1
     except urllib.error.HTTPError as error:
         sys.stderr.write(f"Craft API returned HTTP {error.code}\n")
         detail = error.read().decode("utf-8", errors="replace")

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 .copilot/skills/*
 .config/agent-skills/skills/.DS_Store
 superassistant/AGENTS.local.md
+__pycache__/
+*.py[cod]

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -31,3 +31,5 @@ done
 for file in "${zsh_files[@]}"; do
   zsh -n "$file"
 done
+
+python3 -m unittest discover -s tests -p 'test_*.py'

--- a/tests/test_craft_api.py
+++ b/tests/test_craft_api.py
@@ -239,24 +239,31 @@ extendedKeyUsage = serverAuth
         self.assertNotIn(TEST_CREDENTIAL, result.stderr)
 
     def test_allows_same_origin_https_redirect_with_credentials(self) -> None:
-        server = self.start_server(use_tls=True)
-        server.redirect_to = (
-            f"https://localhost:{server.server_port}/api/v1/final"
-        )
+        auth_modes = {
+            "bearer": ("authorization", f"Bearer {TEST_CREDENTIAL}"),
+            "x-craft-api-key": ("x_craft_api_key", TEST_CREDENTIAL),
+        }
+        for auth_mode, (header_name, expected_value) in auth_modes.items():
+            with self.subTest(auth_mode=auth_mode):
+                server = self.start_server(use_tls=True)
+                server.redirect_to = (
+                    f"https://localhost:{server.server_port}/api/v1/final"
+                )
 
-        result = self.run_helper(
-            f"https://localhost:{server.server_port}/api/v1"
-        )
+                result = self.run_helper(
+                    f"https://localhost:{server.server_port}/api/v1",
+                    auth=auth_mode,
+                )
 
-        self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout, '{"ok":true}')
-        self.assertEqual(len(server.requests), 2)
-        self.assertEqual(
-            server.requests[0]["authorization"], f"Bearer {TEST_CREDENTIAL}"
-        )
-        self.assertEqual(
-            server.requests[1]["authorization"], f"Bearer {TEST_CREDENTIAL}"
-        )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, '{"ok":true}')
+                self.assertEqual(len(server.requests), 2)
+                self.assertEqual(
+                    server.requests[0][header_name], expected_value
+                )
+                self.assertEqual(
+                    server.requests[1][header_name], expected_value
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_craft_api.py
+++ b/tests/test_craft_api.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+import http.server
+import os
+from pathlib import Path
+import shutil
+import ssl
+import subprocess
+import sys
+import tempfile
+import threading
+from typing import Optional
+import unittest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CRAFT_API_HELPER = (
+    REPO_ROOT / ".agents/skills/productivity/craft-api/scripts/craft_api.py"
+)
+TEST_CREDENTIAL = "unit-test-credential"
+
+
+class RecordingHandler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self) -> None:
+        self.server.requests.append(
+            {
+                "path": self.path,
+                "authorization": self.headers.get("Authorization"),
+                "x_craft_api_key": self.headers.get("x-craft-api-key"),
+            }
+        )
+        if self.path == "/api/v1/start" and self.server.redirect_to:
+            self.send_response(302)
+            self.send_header("Location", self.server.redirect_to)
+            self.end_headers()
+            return
+
+        payload = b'{"ok":true}'
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+    def log_message(self, _format: str, *_args: object) -> None:
+        pass
+
+
+class CraftApiTransportTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        openssl = shutil.which("openssl")
+        if openssl is None:
+            raise RuntimeError("openssl is required for Craft API transport tests")
+
+        cls.temp_dir = tempfile.TemporaryDirectory()
+        temp_path = Path(cls.temp_dir.name)
+        cls.cert_path = temp_path / "cert.pem"
+        cls.key_path = temp_path / "key.pem"
+        openssl_config = temp_path / "openssl.cnf"
+        openssl_config.write_text(
+            """
+[req]
+distinguished_name = subject
+x509_extensions = extensions
+prompt = no
+
+[subject]
+CN = localhost
+
+[extensions]
+subjectAltName = DNS:localhost
+basicConstraints = critical,CA:TRUE
+keyUsage = critical,digitalSignature,keyEncipherment,keyCertSign
+extendedKeyUsage = serverAuth
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        subprocess.run(
+            [
+                openssl,
+                "req",
+                "-x509",
+                "-newkey",
+                "rsa:2048",
+                "-nodes",
+                "-days",
+                "1",
+                "-config",
+                str(openssl_config),
+                "-keyout",
+                str(cls.key_path),
+                "-out",
+                str(cls.cert_path),
+            ],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.temp_dir.cleanup()
+
+    def start_server(
+        self, *, use_tls: bool, redirect_to: Optional[str] = None
+    ) -> http.server.ThreadingHTTPServer:
+        server = http.server.ThreadingHTTPServer(
+            ("127.0.0.1", 0), RecordingHandler
+        )
+        server.requests = []
+        server.redirect_to = redirect_to
+        if use_tls:
+            tls_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+            tls_context.load_cert_chain(self.cert_path, self.key_path)
+            server.socket = tls_context.wrap_socket(server.socket, server_side=True)
+
+        thread = threading.Thread(target=server.serve_forever, daemon=True)
+        thread.start()
+        self.addCleanup(server.server_close)
+        self.addCleanup(thread.join)
+        self.addCleanup(server.shutdown)
+        return server
+
+    def run_helper(
+        self, base_url: str, *, auth: str = "bearer"
+    ) -> subprocess.CompletedProcess[str]:
+        environment = {
+            "CRAFT_API_BASE_URL": base_url,
+            "CRAFT_API_KEY": TEST_CREDENTIAL,
+            "PATH": os.environ.get("PATH", ""),
+            "SSL_CERT_FILE": str(self.cert_path),
+        }
+        return subprocess.run(
+            [
+                sys.executable,
+                str(CRAFT_API_HELPER),
+                "GET",
+                "/start",
+                "--auth",
+                auth,
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
+
+    def test_rejects_cleartext_base_url_before_sending_credentials(self) -> None:
+        server = self.start_server(use_tls=False)
+
+        result = self.run_helper(
+            f"http://localhost:{server.server_port}/api/v1"
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("must use HTTPS", result.stderr)
+        self.assertEqual(server.requests, [])
+        self.assertNotIn(TEST_CREDENTIAL, result.stdout)
+        self.assertNotIn(TEST_CREDENTIAL, result.stderr)
+
+    def test_rejects_base_url_userinfo_before_sending_credentials(self) -> None:
+        server = self.start_server(use_tls=True)
+
+        result = self.run_helper(
+            f"https://user:password@localhost:{server.server_port}/api/v1"
+        )
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("must not include userinfo", result.stderr)
+        self.assertEqual(server.requests, [])
+        self.assertNotIn(TEST_CREDENTIAL, result.stdout)
+        self.assertNotIn(TEST_CREDENTIAL, result.stderr)
+
+    def test_blocks_cross_origin_redirect_before_forwarding_credentials(self) -> None:
+        auth_modes = {
+            "bearer": ("authorization", f"Bearer {TEST_CREDENTIAL}"),
+            "x-craft-api-key": ("x_craft_api_key", TEST_CREDENTIAL),
+        }
+        for auth_mode, (header_name, expected_value) in auth_modes.items():
+            with self.subTest(auth_mode=auth_mode):
+                redirected_server = self.start_server(use_tls=True)
+                redirect_target = (
+                    f"https://localhost:{redirected_server.server_port}/api/v1/final"
+                )
+                initial_server = self.start_server(
+                    use_tls=True, redirect_to=redirect_target
+                )
+
+                result = self.run_helper(
+                    f"https://localhost:{initial_server.server_port}/api/v1",
+                    auth=auth_mode,
+                )
+
+                self.assertEqual(len(initial_server.requests), 1)
+                self.assertEqual(
+                    initial_server.requests[0][header_name], expected_value
+                )
+                self.assertEqual(redirected_server.requests, [])
+                self.assertEqual(result.returncode, 1)
+                self.assertIn("blocked unsafe redirect", result.stderr)
+                self.assertNotIn(TEST_CREDENTIAL, result.stdout)
+                self.assertNotIn(TEST_CREDENTIAL, result.stderr)
+
+    def test_blocks_https_to_http_redirect_before_forwarding_credentials(self) -> None:
+        redirected_server = self.start_server(use_tls=False)
+        initial_server = self.start_server(
+            use_tls=True,
+            redirect_to=(
+                f"http://localhost:{redirected_server.server_port}/api/v1/final"
+            ),
+        )
+
+        result = self.run_helper(
+            f"https://localhost:{initial_server.server_port}/api/v1"
+        )
+
+        self.assertEqual(len(initial_server.requests), 1)
+        self.assertEqual(redirected_server.requests, [])
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("blocked unsafe redirect", result.stderr)
+        self.assertNotIn(TEST_CREDENTIAL, result.stdout)
+        self.assertNotIn(TEST_CREDENTIAL, result.stderr)
+
+    def test_blocks_redirect_userinfo_before_forwarding_credentials(self) -> None:
+        server = self.start_server(use_tls=True)
+        server.redirect_to = (
+            f"https://user:password@localhost:{server.server_port}/api/v1/final"
+        )
+
+        result = self.run_helper(
+            f"https://localhost:{server.server_port}/api/v1"
+        )
+
+        self.assertEqual(len(server.requests), 1)
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("blocked unsafe redirect", result.stderr)
+        self.assertNotIn(TEST_CREDENTIAL, result.stdout)
+        self.assertNotIn(TEST_CREDENTIAL, result.stderr)
+
+    def test_allows_same_origin_https_redirect_with_credentials(self) -> None:
+        server = self.start_server(use_tls=True)
+        server.redirect_to = (
+            f"https://localhost:{server.server_port}/api/v1/final"
+        )
+
+        result = self.run_helper(
+            f"https://localhost:{server.server_port}/api/v1"
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, '{"ok":true}')
+        self.assertEqual(len(server.requests), 2)
+        self.assertEqual(
+            server.requests[0]["authorization"], f"Bearer {TEST_CREDENTIAL}"
+        )
+        self.assertEqual(
+            server.requests[1]["authorization"], f"Bearer {TEST_CREDENTIAL}"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- require `CRAFT_API_BASE_URL` to be an absolute HTTPS URL without userinfo
- follow redirects only when scheme, hostname, and effective port remain exactly same-origin
- block cross-origin, cleartext, downgrade, and userinfo redirect targets before forwarding either supported credential header
- keep same-origin HTTPS redirects working
- add the focused transport regression suite to the repository check

## Root cause

The helper attached the Craft API credential to a `urllib` request while accepting HTTP endpoints and relying on the default redirect-capable opener. A redirect could therefore forward either supported credential header to a different origin.

## Validation

The pre-fix regression run demonstrated that both bearer and `x-craft-api-key` credentials reached a second HTTPS loopback server on a different port.

The patched suite verifies:

- cleartext base URLs fail before any request
- base URLs containing userinfo fail before any request
- cross-origin HTTPS redirects are blocked for both credential modes
- HTTPS-to-HTTP redirects are blocked
- redirect targets containing userinfo are blocked
- approved same-origin HTTPS redirects still succeed with authentication

Checks:

- `./scripts/check.sh`
- `python3 -m unittest -v tests/test_craft_api.py`
- `python3.9 -m unittest -v tests/test_craft_api.py`
- `python3 -m py_compile .agents/skills/productivity/craft-api/scripts/craft_api.py tests/test_craft_api.py`
- `python3.9 -m py_compile .agents/skills/productivity/craft-api/scripts/craft_api.py tests/test_craft_api.py`
- `git diff --check origin/main...HEAD`

All network validation used temporary localhost servers and a dummy credential.

Fixes #48