### PR TITLE
Fix regressions in slimmed agent skills

### DIFF
--- a/.agents/skills/development/pr-babysitter/references/codex-review-signals.md
+++ b/.agents/skills/development/pr-babysitter/references/codex-review-signals.md
@@ -3,7 +3,7 @@
 GitHub exposes PR-body reactions through the issue reactions API because every pull request is also an issue:
 
 ```bash
-gh api 'repos/{owner}/{repo}/issues/<pr>/reactions?content=%2B1' --paginate \
+gh api 'repos/{owner}/{repo}/issues/<pr>/reactions' --paginate \
   --jq '.[] | {id, user: .user.login, content, created_at}'
 ```
 

--- a/.agents/skills/productivity/matter-cli/SKILL.md
+++ b/.agents/skills/productivity/matter-cli/SKILL.md
@@ -46,7 +46,3 @@ One task per article, with:
 - The Matter app link in the visible title: `Read: [<article title>](https://www.getmatter.com/d/entry/<numeric-content-id>)`
 - Description lines: `matter:item:<id>` (dedupe key), `Matter content id: <numeric-content-id>`, and `Source URL: <original url>`.
 - The `read` Todoist label only — no `matter` label. Preserve existing due date/priority choices unless asked to change them.
-
-## Automation
-
-The durable automation lives at `${CODEX_HOME:-$HOME/.codex}/automations/matter-reading-queue/` (`automation.toml`, `memory.md`). After editing it, validate the TOML with `python3 -c 'import tomllib, pathlib; tomllib.loads(pathlib.Path("<path>/automation.toml").read_text())'`.

--- a/.agents/skills/productivity/mela-recipe-manager/SKILL.md
+++ b/.agents/skills/productivity/mela-recipe-manager/SKILL.md
@@ -14,7 +14,7 @@ description: Manage Pablo's Mela recipe library from Codex. Use for reading/sear
 
 ## Setup
 
-Preferred command: `"$HOME/.local/bin/mela" doctor --format json` — a wrapper to a pinned venv with `mela-cli==1.0.1`. If missing, recreate: `python3 -m venv "$HOME/.local/share/mela-cli-venv"`, `pip install mela-cli==1.0.1` in that venv, then create the `$HOME/.local/bin/mela` wrapper.
+Preferred command: `"$HOME/.local/bin/mela" doctor --format json` — a wrapper to a pinned venv with `mela-cli==1.0.1`. If missing, recreate: `python3 -m venv "$HOME/.local/share/mela-cli-venv"`, `"$HOME/.local/share/mela-cli-venv/bin/python" -m pip install mela-cli==1.0.1`, then create the `$HOME/.local/bin/mela` wrapper.
 
 ## Reads
 

--- a/.agents/skills/productivity/tripsy-cli/SKILL.md
+++ b/.agents/skills/productivity/tripsy-cli/SKILL.md
@@ -7,7 +7,14 @@ description: Work with Tripsy travel data through the local Tripsy CLI. Use when
 
 ## Core rules
 
-- Prefer `$HOME/.local/bin/tripsy`, falling back to `command -v tripsy`. Treat the remote Tripsy MCP as optional — prefer the CLI when the MCP does not expose tools or has session/auth instability.
+- Resolve the CLI once per shell, preferring the local install:
+
+```bash
+TRIPSY_BIN="$HOME/.local/bin/tripsy"
+test -x "$TRIPSY_BIN" || TRIPSY_BIN="$(command -v tripsy)"
+```
+
+- Treat the remote Tripsy MCP as optional — prefer the CLI when the MCP does not expose tools or has session/auth instability.
 - Prove access before claiming Tripsy works: `"$TRIPSY_BIN" doctor` and `"$TRIPSY_BIN" auth status --json`.
 - Prefer `--json` for agent work; `--quiet` for raw JSON only.
 - No create/update/delete/upload/attach unless the user asked for that exact mutation.

--- a/.agents/skills/productivity/tripsy-cli/SKILL.md
+++ b/.agents/skills/productivity/tripsy-cli/SKILL.md
@@ -12,6 +12,10 @@ description: Work with Tripsy travel data through the local Tripsy CLI. Use when
 ```bash
 TRIPSY_BIN="$HOME/.local/bin/tripsy"
 test -x "$TRIPSY_BIN" || TRIPSY_BIN="$(command -v tripsy)"
+if ! test -x "$TRIPSY_BIN"; then
+  echo "Tripsy CLI unavailable" >&2
+  exit 1
+fi
 ```
 
 - Treat the remote Tripsy MCP as optional — prefer the CLI when the MCP does not expose tools or has session/auth instability.

--- a/.agents/skills/review-planning/backlog-planner/SKILL.md
+++ b/.agents/skills/review-planning/backlog-planner/SKILL.md
@@ -5,7 +5,7 @@ description: "Create or refine backlog items with clear scope and acceptance cri
 
 # Backlog Planner
 
-Turn ideas into issues an agent or human can implement without private chat history. Search for duplicates and in-flight PRs before creating; read the full issue, comments, labels, related PRs, and board status before changing an existing one. Ask before bulk-creating issues unless the user explicitly requested filing them.
+Turn ideas into issues an agent or human can implement without private chat history. Search for duplicates and in-flight PRs before creating; read the full issue, comments, labels, related PRs, and board status before changing an existing one. Before any write, resolve the repository and authenticated account with `gh repo view` and `gh auth status`, then inspect the repository's labels and project fields. Follow repository policy; use the taxonomy below only where those labels and status values already exist, and never create or rename taxonomy unless asked. Ask before bulk-creating issues unless the user explicitly requested filing them.
 
 ## Issue quality bar
 
@@ -16,7 +16,7 @@ Turn ideas into issues an agent or human can implement without private chat hist
 - Validation plan matched to the changed surface: unit, integration, local server, simulator, or manual API checks.
 - Scope fits a focused PR, or the planned slices are named. Split work that spans multiple components or has unclear sequencing.
 
-## Readiness labels — one active at a time
+## Default readiness labels — one active at a time
 
 - `ai-needs-review`: body materially drafted or rewritten by AI; needs human review.
 - `needs-grooming`: human-reviewed but still missing scope, acceptance criteria, blockers, or validation detail.
@@ -28,7 +28,7 @@ Labels classify and gate readiness; execution state lives on the project board. 
 
 ## Project board status
 
-Standard flow: `Backlog` → `Next` → `Ready` → `In progress` → `In review` → `Done`. New issues start in `Backlog`; near-term but blocked or not-yet-ready priorities go to `Next`; `agent-ready` work goes to `Ready`; actively owned work to `In progress`; open-PR work to `In review`. If board tooling is unavailable, report the intended status change instead of inventing substitute labels.
+When the board defines these values, use `Backlog` → `Next` → `Ready` → `In progress` → `In review` → `Done`. New issues start in `Backlog`; near-term but blocked or not-yet-ready priorities go to `Next`; `agent-ready` work goes to `Ready`; actively owned work to `In progress`; open-PR work to `In review`. If board tooling is unavailable, report the intended status change instead of inventing substitute labels.
 
 ## GitHub as live artifact
 

--- a/.agents/skills/review-planning/backlog-planner/SKILL.md
+++ b/.agents/skills/review-planning/backlog-planner/SKILL.md
@@ -28,7 +28,7 @@ Labels classify and gate readiness; execution state lives on the project board. 
 
 ## Project board status
 
-When the board defines these values, use `Backlog` → `Next` → `Ready` → `In progress` → `In review` → `Done`. New issues start in `Backlog`; near-term but blocked or not-yet-ready priorities go to `Next`; `agent-ready` work goes to `Ready`; actively owned work to `In progress`; open-PR work to `In review`. If board tooling is unavailable, report the intended status change instead of inventing substitute labels.
+When the board defines these values, use `Backlog` → `Next` → `Ready` → `In progress` → `In review` → `Done`. New issues start in `Backlog`; near-term but blocked or not-yet-ready priorities go to `Next`; `agent-ready` work goes to `Ready`; actively owned work to `In progress`; open-PR work to `In review`. With different status names, map each semantic stage to the closest existing value. If no equivalent exists or board tooling is unavailable, report the intended transition instead of creating fields, statuses, or substitute labels.
 
 ## GitHub as live artifact
 


### PR DESCRIPTION
## Summary

- initialize the Tripsy CLI path before documented commands use it
- inspect all PR reactions so active Codex `eyes` locks are visible
- use the pinned Mela virtual environment for installation
- remove Matter automation configuration from the Matter CLI skill
- make backlog labels and project states conditional on the target repository

The changes preserve the slimmer GPT-5.6-oriented skill structure and do not restore the deleted Python test suites or redundant general-agent guidance.

## Validation

- `./scripts/check.sh`
- `git diff --check`
- skill frontmatter checks
- live Tripsy binary resolution and doctor probe
- live Mela wrapper and pinned-venv probe
- unfiltered GitHub reactions endpoint probe
- staged-diff secret-pattern scan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified pull-request reaction retrieval by updating the documented `gh api` command to paginate reactions without filtering to “+1”.
  * Updated Matter CLI documentation by removing the automation section.
  * Improved `mela` doctor setup guidance to ensure the CLI is installed inside the created virtual environment.
  * Refined Tripsy CLI resolution rules, including a clear error when the CLI is unavailable and notes about optional remote exposure.
  * Enhanced backlog-planning guidance with an up-front context/checklist, duplicate/in-flight PR review, and safer bulk-change requirements, including refined readiness/project-board wording.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->